### PR TITLE
Changes to autocomplete search setup to support multiple entries with the same 'name'

### DIFF
--- a/app/views/application/search/subject-search.html
+++ b/app/views/application/search/subject-search.html
@@ -28,988 +28,5893 @@
     <script type="text/javascript">
 
       var results = [
-        { "name": "Abattoir Worker", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Academic Professional", "qualType": "End-Point Assessment", "level": "Level 7" },
-        { "name": "Accident repair technician", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Accountancy or taxation professional", "qualType": "End-Point Assessment", "level": "Level 7" },
-        { "name": "Accounting", "qualType": "A Level", "level": "Level 3" },
-        { "name": "Accounting", "qualType": "T Level", "level": "Level 3" },
-        { "name": "Accounting", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Accounts or finance assistant", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Acoustics Technician", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Actuarial Technician", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Actuary", "qualType": "End-Point Assessment", "level": "Level 7" },
-        { "name": "Additional mathematics", "qualType": "GCSE", "level": "Level 2" },
-        { "name": "Additional mathematics", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Adult Care Worker", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Advanced and Creative Hair Professional", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Advanced Beauty Therapist", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Advanced Butcher", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Advanced Carpentry and Joinery", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Advanced clinical practitioner (integrated degree)", "qualType": "End-Point Assessment", "level": "Level 7" },
-        { "name": "Advanced credit controller and Debt collection specialist", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Advanced Dairy Technologist", "qualType": "End-Point Assessment", "level": "Level 5" },
-        { "name": "Advanced Forensic Practitioner (Custody or Sexual Offence)", "qualType": "End-Point Assessment", "level": "Level 7" },
-        { "name": "Advanced Furniture CNC Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Advanced Golf Greenkeeper", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Advanced Upholsterer", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Advertising and Media Executive", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Aerospace engineer (degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Aerospace software development engineer (degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Agriculture", "qualType": "GCSE", "level": "Level 2" },
-        { "name": "Agriculture", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Agriculture or horticulture professional adviser", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Agriculture, Land Management and Production", "qualType": "T Level", "level": "Level 3" },
-        { "name": "Air Traffic Controller", "qualType": "End-Point Assessment", "level": "Level 5" },
-        { "name": "Aircraft Certifying Technician", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Ambulance Support Worker (emergency, urgent, and non-urgent)", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Ancient history", "qualType": "GCSE", "level": "Level 2" },
-        { "name": "Ancient history", "qualType": "A Level", "level": "Level 3" },
-        { "name": "Ancient history", "qualType": "AS Level", "level": "Level 3" },
-        { "name": "Ancient history", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Animal Care and Management", "qualType": "T Level", "level": "Level 3" },
-        { "name": "Animal Care and Welfare Assistant", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Animal Technologist", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Animal Trainer", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Animation", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Anti-Social Behaviour and Community Safety Officer", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Applications support lead", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Applied Biology", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Applied Psychology", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Applied Science", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Arabic", "qualType": "GCSE", "level": "Level 2" },
-        { "name": "Arabic", "qualType": "A Level", "level": "Level 3" },
-        { "name": "Arabic", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Arboriculturist", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Arborist", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Archaeological specialist (Degree)", "qualType": "End-Point Assessment", "level": "Level 7" },
-        { "name": "Archaeological Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Architect (integrated degree)", "qualType": "End-Point Assessment", "level": "Level 7" },
-        { "name": "Architectural assistant (integrated degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Archivist and Records Manager", "qualType": "End-Point Assessment", "level": "Level 7" },
-        { "name": "Art", "qualType": "GCSE", "level": "Level 2" },
-        { "name": "Art", "qualType": "A Level", "level": "Level 3" },
-        { "name": "Art", "qualType": "AS Level", "level": "Level 3" },
-        { "name": "Art", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Art: 3D studies", "qualType": "GCSE", "level": "Level 2" },
-        { "name": "Art: 3D studies", "qualType": "A Level", "level": "Level 3" },
-        { "name": "Art: 3D studies", "qualType": "AS Level", "level": "Level 3" },
-        { "name": "Art: 3D studies", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Art: Crafts", "qualType": "GCSE", "level": "Level 2" },
-        { "name": "Art: Crafts", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Art: Critical studies", "qualType": "GCSE", "level": "Level 2" },
-        { "name": "Art: Critical studies", "qualType": "A Level", "level": "Level 3" },
-        { "name": "Art: Critical studies", "qualType": "AS Level", "level": "Level 3" },
-        { "name": "Art: Critical studies", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Art: Fine art", "qualType": "GCSE", "level": "Level 2" },
-        { "name": "Art: Fine art", "qualType": "A Level", "level": "Level 3" },
-        { "name": "Art: Fine art", "qualType": "AS Level", "level": "Level 3" },
-        { "name": "Art: Fine art", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Art: Graphics", "qualType": "GCSE", "level": "Level 2" },
-        { "name": "Art: Graphics", "qualType": "A Level", "level": "Level 3" },
-        { "name": "Art: Graphics", "qualType": "AS Level", "level": "Level 3" },
-        { "name": "Art: Graphics", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Art: History of art", "qualType": "A Level", "level": "Level 3" },
-        { "name": "Art: History of art", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Art: Photography", "qualType": "GCSE", "level": "Level 2" },
-        { "name": "Art: Photography", "qualType": "A Level", "level": "Level 3" },
-        { "name": "Art: Photography", "qualType": "AS Level", "level": "Level 3" },
-        { "name": "Art: Photography", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Art: Textiles", "qualType": "GCSE", "level": "Level 2" },
-        { "name": "Art: Textiles", "qualType": "A Level", "level": "Level 3" },
-        { "name": "Art: Textiles", "qualType": "AS Level", "level": "Level 3" },
-        { "name": "Art: Textiles", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Artificial Intelligence (AI) Data Specialist", "qualType": "End-Point Assessment", "level": "Level 7" },
-        { "name": "Arts Therapist (Degree)", "qualType": "End-Point Assessment", "level": "Level 7" },
-        { "name": "Asbestos Analyst and Surveyor", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Assessor Coach", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Asset manager", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Assistant Accountant", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Assistant buyer and assistant merchandiser", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Assistant Puppet Maker", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Assistant recording technician", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Assistant technical director  (visual effects)", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Associate Ambulance Practitioner", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Associate Continuing Healthcare Practitioner", "qualType": "End-Point Assessment", "level": "Level 5" },
-        { "name": "Associate Project Manager", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Astronomy", "qualType": "GCSE", "level": "Level 2" },
-        { "name": "Astronomy", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Autocare Technician", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Automation & Controls Engineering Technician", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Automotive Glazing Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Aviation Customer Service", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Aviation Ground Handler", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Aviation ground operative (above wing)", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Aviation Ground Specialist", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Aviation Maintenance Mechanic (Military)", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Aviation movement specialist", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Aviation Operations Manager", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Baker", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Beauty and Make Up Consultant", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Beauty Therapist", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "BEMS (Building energy management systems) controls engineer", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Bengali", "qualType": "GCSE", "level": "Level 2" },
-        { "name": "Bengali", "qualType": "A Level", "level": "Level 3" },
-        { "name": "Bengali", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Bespoke Furniture Maker", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Bespoke Saddler", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Bespoke Tailor and Cutter", "qualType": "End-Point Assessment", "level": "Level 5" },
-        { "name": "Biblical Hebrew", "qualType": "GCSE", "level": "Level 2" },
-        { "name": "Biblical Hebrew", "qualType": "A Level", "level": "Level 3" },
-        { "name": "Biblical Hebrew", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Bicycle mechanic", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Bid and Proposal Co-ordinator", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Bioinformatics scientist", "qualType": "End-Point Assessment", "level": "Level 7" },
-        { "name": "Biology", "qualType": "GCSE", "level": "Level 2" },
-        { "name": "Biology", "qualType": "A Level", "level": "Level 3" },
-        { "name": "Biology", "qualType": "AS Level", "level": "Level 3" },
-        { "name": "Biology", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Blacksmith", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Boatbuilder", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Boatmaster", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Bookbinder", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Brewer", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Bricklayer", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Broadcast and Communications Technical Operator", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Broadcast and media systems engineer (integrated degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Broadcast and Media Systems Technician", "qualType": "End-Point Assessment", "level": "Level 5" },
-        { "name": "Broadcast Production Assistant", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Building Control Surveyor (integrated degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Building services design engineer (degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Building Services Engineering Craftsperson", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Building Services Engineering Ductwork Craftsperson", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Building Services Engineering Ductwork installer", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Building Services Engineering for Construction", "qualType": "T Level", "level": "Level 3" },
-        { "name": "Building Services Engineering Installer", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Building Services Engineering Service & Maintenance Engineer", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Building Services Engineering Site Management", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Building Services Engineering Technician", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Building services engineering technician 2022", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Building services engineering ventilation hygiene technician", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Bus and Coach Engineering Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Business", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Business Administrator", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Business Analyst", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Business and communication systems", "qualType": "GCSE", "level": "Level 2" },
-        { "name": "Business and communication systems", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Business Fire Safety Advisor", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Business studies", "qualType": "GCSE", "level": "Level 2" },
-        { "name": "Business studies", "qualType": "A Level", "level": "Level 3" },
-        { "name": "Business studies", "qualType": "AS Level", "level": "Level 3" },
-        { "name": "Business studies", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Business to Business Sales Professional (integrated degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Butcher", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Buying and merchandising assistant", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Cabin Crew", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Camera Prep Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Career Development Professional", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Carpentry and Joinery", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Catering", "qualType": "T Level", "level": "Level 3" },
-        { "name": "Chartered Landscape Professional", "qualType": "End-Point Assessment", "level": "Level 7" },
-        { "name": "Chartered Legal Executive", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Chartered Manager Degree Apprenticeship", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Chartered Surveyor", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Chartered Town Planner (Degree)", "qualType": "End-Point Assessment", "level": "Level 7" },
-        { "name": "Chef de partie", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Chemistry", "qualType": "GCSE", "level": "Level 2" },
-        { "name": "Chemistry", "qualType": "A Level", "level": "Level 3" },
-        { "name": "Chemistry", "qualType": "AS Level", "level": "Level 3" },
-        { "name": "Chemistry", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Children, Young People and Families Manager", "qualType": "End-Point Assessment", "level": "Level 5" },
-        { "name": "Children, Young People and Families Practitioner", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Chinese", "qualType": "GCSE", "level": "Level 2" },
-        { "name": "Chinese", "qualType": "A Level", "level": "Level 3" },
-        { "name": "Chinese", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Church minister (integrated degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Citizenship studies", "qualType": "GCSE", "level": "Level 2" },
-        { "name": "Citizenship studies", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Civil Engineer", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Civil Engineering Site Management", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Civil engineering technician", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Classical civilisation", "qualType": "GCSE", "level": "Level 2" },
-        { "name": "Classical civilisation", "qualType": "A Level", "level": "Level 3" },
-        { "name": "Classical civilisation", "qualType": "AS Level", "level": "Level 3" },
-        { "name": "Classical civilisation", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Classical Greek", "qualType": "GCSE", "level": "Level 2" },
-        { "name": "Classical Greek", "qualType": "A Level", "level": "Level 3" },
-        { "name": "Classical Greek", "qualType": "AS Level", "level": "Level 3" },
-        { "name": "Classical Greek", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Classics", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Clinical associate in psychology (CAP) (integrated degree)", "qualType": "End-Point Assessment", "level": "Level 7" },
-        { "name": "Clinical Coder", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Clinical dental technician (integrated)", "qualType": "End-Point Assessment", "level": "Level 5" },
-        { "name": "Clinical pharmacology scientist (integrated degree)", "qualType": "End-Point Assessment", "level": "Level 7" },
-        { "name": "Clinical Scientist", "qualType": "End-Point Assessment", "level": "Level 7" },
-        { "name": "Clinical Trials Specialist", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Clock Maker", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Coaching Professional", "qualType": "End-Point Assessment", "level": "Level 5" },
-        { "name": "Combined science", "qualType": "GCSE", "level": "Level 2" },
-        { "name": "Combined science", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Commercial Catering Equipment Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Commercial Procurement and Supply (formerly Public sector commercial professional)", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Commercial Thermal Insulation Operative", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Commis chef", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Community Activator Coach", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Community Energy Specialist", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Community Health and Wellbeing Worker", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Community Safety Advisor", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Community Sport and Health Officer", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Compliance and risk officer", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Composites Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Compressed air and vacuum technician", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Computing", "qualType": "GCSE", "level": "Level 2" },
-        { "name": "Computing", "qualType": "A Level", "level": "Level 3" },
-        { "name": "Computing", "qualType": "AS Level", "level": "Level 3" },
-        { "name": "Computing", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Construction", "qualType": "GCSE", "level": "Level 2" },
-        { "name": "Construction", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Construction Assembly and Installation Operative", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Construction Design and Build Technician", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Construction Equipment Maintenance Mechanic", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Construction Plant Operative", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Construction Quantity Surveying Technician", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Construction Quantity Surveyor", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Construction Site Engineering Technician", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Construction Site Management", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Construction Site Supervisor", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Construction Support Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Control technical support engineer", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Conveyancing Technician", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Corporate responsibility and sustainability practitioner", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Costume Performance Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Counter Fraud Investigator", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Countryside Ranger", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Countryside Worker", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Craft", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Craft and Design", "qualType": "T Level", "level": "Level 3" },
-        { "name": "Creative Digital", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Creative digital design professional (integrated degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Creative Digital Media", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Creative industries production manager  (degree)", "qualType": "End-Point Assessment", "level": "Level 7" },
-        { "name": "Creative Venue Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Credit Controller and collector", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Crop Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Cultural Heritage Conservation Technician", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Cultural Heritage Conservator", "qualType": "End-Point Assessment", "level": "Level 7" },
-        { "name": "Cultural Learning & Participation Officer", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Curator", "qualType": "End-Point Assessment", "level": "Level 7" },
-        { "name": "Curtain Wall Installer", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Custody & Detention Officer", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Customer Service Practitioner", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Customer Service Specialist", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Cyber Security Technical Professional (Integrated Degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Cyber Security Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Cyber Security Technologist (2021)", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Dance", "qualType": "GCSE", "level": "Level 2" },
-        { "name": "Dance", "qualType": "A Level", "level": "Level 3" },
-        { "name": "Dance", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Dance Theatre", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Data Analyst", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Data Scientist (Integrated Degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Data Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Debt Adviser", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Demolition Operative", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Dental Nurse", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Dental Practice Manager", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Dental Technician (Integrated)", "qualType": "End-Point Assessment", "level": "Level 5" },
-        { "name": "Design", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Design and Construction Management (Degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Design and Development for Engineering and Manufacturing", "qualType": "T Level", "level": "Level 3" },
-        { "name": "Design and technology", "qualType": "GCSE", "level": "Level 2" },
-        { "name": "Design and technology", "qualType": "A Level", "level": "Level 3" },
-        { "name": "Design and technology", "qualType": "AS Level", "level": "Level 3" },
-        { "name": "Design and technology", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Design, Surveying and Planning for Construction", "qualType": "T Level", "level": "Level 3" },
-        { "name": "DevOps Engineer", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Diagnostic Radiographer (Integrated Degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Dietitian (integrated degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Digital Accessibility Specialist", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Digital and Technology Solutions Professional (integrated degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Digital and Technology Solutions Specialist (integrated degree)", "qualType": "End-Point Assessment", "level": "Level 7" },
-        { "name": "Digital Business Services", "qualType": "T Level", "level": "Level 3" },
-        { "name": "Digital Community Manager", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Digital Engineering Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Digital Games", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Digital Marketer", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Digital marketer integrated degree", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Digital Media", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Digital Production, Design and Development", "qualType": "T Level", "level": "Level 3" },
-        { "name": "Digital Support Services", "qualType": "T Level", "level": "Level 3" },
-        { "name": "Digital Support Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Digital User Experience (UX) Professional (Integrated Degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "District Nurse", "qualType": "End-Point Assessment", "level": "Level 7" },
-        { "name": "Dog groomer", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Drama", "qualType": "GCSE", "level": "Level 2" },
-        { "name": "Drama", "qualType": "A Level", "level": "Level 3" },
-        { "name": "Drama", "qualType": "AS Level", "level": "Level 3" },
-        { "name": "Drama", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Drinks dispense technician", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Dual Fuel Smart Meter Installer", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Early intervention practitioner", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Early years educator", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Early Years Practitioner", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Ecologist", "qualType": "End-Point Assessment", "level": "Level 7" },
-        { "name": "Economics", "qualType": "GCSE", "level": "Level 2" },
-        { "name": "Economics", "qualType": "A Level", "level": "Level 3" },
-        { "name": "Economics", "qualType": "AS Level", "level": "Level 3" },
-        { "name": "Economics", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Education and Childcare", "qualType": "T Level", "level": "Level 3" },
-        { "name": "Education Technician (HE Assistant Technician & Simulation-based Technician)", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Electrical Electronic Product Servicing and Installation Engineer", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Electrical or electronic technical support engineer (degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Electrical power networks engineer", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Electrical power protection and plant commissioning engineer", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Electro-mechanical engineer", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Electronic Systems Principal Engineer", "qualType": "End-Point Assessment", "level": "Level 7" },
-        { "name": "Electronics", "qualType": "GCSE", "level": "Level 2" },
-        { "name": "Electronics", "qualType": "A Level", "level": "Level 3" },
-        { "name": "Electronics", "qualType": "AS Level", "level": "Level 3" },
-        { "name": "Electronics", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Embedded electronic systems design and development engineer (degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Emergency Service Contact Handler", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Employability Practitioner", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Engineer Surveyor", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Engineering", "qualType": "GCSE", "level": "Level 2" },
-        { "name": "Engineering", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Engineering construction erector rigger", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Engineering Construction Pipefitter", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Engineering design and draughtsperson", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Engineering fitter", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Engineering Manufacturing Technician", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Engineering Operative", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Engineering Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Engineering, Manufacturing, Processing and Control", "qualType": "T Level", "level": "Level 3" },
-        { "name": "English language", "qualType": "GCSE", "level": "Level 2" },
-        { "name": "English language", "qualType": "A Level", "level": "Level 3" },
-        { "name": "English language", "qualType": "AS Level", "level": "Level 3" },
-        { "name": "English language", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "English language and literature", "qualType": "A Level", "level": "Level 3" },
-        { "name": "English language and literature", "qualType": "AS Level", "level": "Level 3" },
-        { "name": "English literature", "qualType": "GCSE", "level": "Level 2" },
-        { "name": "English literature", "qualType": "A Level", "level": "Level 3" },
-        { "name": "English literature", "qualType": "AS Level", "level": "Level 3" },
-        { "name": "English literature", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Enhanced Clinical Practitioner", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Environmental health practitioner (integrated degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Environmental practitioner", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Environmental Science", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Environmental studies", "qualType": "A Level", "level": "Level 3" },
-        { "name": "Environmental studies", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Environmental technology", "qualType": "A Level", "level": "Level 3" },
-        { "name": "Environmental technology", "qualType": "AS Level", "level": "Level 3" },
-        { "name": "Environmental technology", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Equine groom", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Event Assistant", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Express delivery Manager", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Express delivery operative", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Express delivery sortation hub operative", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Facilities Management Supervisor", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Facilities Manager", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Facilities Services Operative", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Fall Protection Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Farrier", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Fashion and Textiles Pattern Cutter", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Fashion and textiles product technologist", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Fashion Studio Assistant", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Fencing Installer", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Fenestration fabricator", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Fenestration Installer", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Film", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Film Studies", "qualType": "GCSE", "level": "Level 2" },
-        { "name": "Film studies", "qualType": "A Level", "level": "Level 3" },
-        { "name": "Film studies", "qualType": "AS Level", "level": "Level 3" },
-        { "name": "Film studies", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Finance", "qualType": "T Level", "level": "Level 3" },
-        { "name": "Financial Advisor", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Financial Services Administrator", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Financial Services Customer Adviser", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Financial Services Professional", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Fire Emergency and Security Systems Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Fire Safety Engineer (Degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Fire Safety Inspector", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "First Officer Pilot", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Fisher", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Fishmonger", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Fitted Furniture Design Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Floorlayer", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Florist", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Food", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Food and drink advanced engineer (integrated degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Food and Drink Engineer", "qualType": "End-Point Assessment", "level": "Level 5" },
-        { "name": "Food and Drink Maintenance Engineer", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Food and drink process operator", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Food and drink technical operator", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Food industry technical professional (integrated degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Food preparation and nutrition", "qualType": "GCSE", "level": "Level 2" },
-        { "name": "Food preparation and nutrition", "qualType": "GCSE", "level": "Level 2" },
-        { "name": "Food preparation and nutrition", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Food Technologist", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Footwear manufacturer", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Forensic Collision Investigator", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Forest Operative", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Formworker", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "French", "qualType": "GCSE", "level": "Level 2" },
-        { "name": "French", "qualType": "A Level", "level": "Level 3" },
-        { "name": "French", "qualType": "AS Level", "level": "Level 3" },
-        { "name": "French", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Fundraiser", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Funeral Director", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Funeral Team Member", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Furniture Manufacturer", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Further mathematics", "qualType": "GCSE", "level": "Level 2" },
-        { "name": "Further mathematics", "qualType": "A Level", "level": "Level 3" },
-        { "name": "Further mathematics", "qualType": "AS Level", "level": "Level 3" },
-        { "name": "Further mathematics", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Game programmer", "qualType": "End-Point Assessment", "level": "Level 7" },
-        { "name": "Garment Maker", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Gas Engineering Operative", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Gas Network Craftsperson", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Gas Network Operative", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "General farm worker", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "General Welder (Arc Processes)", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Geography", "qualType": "GCSE", "level": "Level 2" },
-        { "name": "Geography", "qualType": "A Level", "level": "Level 3" },
-        { "name": "Geography", "qualType": "AS Level", "level": "Level 3" },
-        { "name": "Geography", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Geology", "qualType": "GCSE", "level": "Level 2" },
-        { "name": "Geology", "qualType": "A Level", "level": "Level 3" },
-        { "name": "Geology", "qualType": "AS Level", "level": "Level 3" },
-        { "name": "Geology", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Geospatial Mapping and Science Specialist (Degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Geospatial Survey Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Geotechnical engineer (integrated degree)", "qualType": "End-Point Assessment", "level": "Level 7" },
-        { "name": "German", "qualType": "GCSE", "level": "Level 2" },
-        { "name": "German", "qualType": "A Level", "level": "Level 3" },
-        { "name": "German", "qualType": "AS Level", "level": "Level 3" },
-        { "name": "German", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Golf Course Manager", "qualType": "End-Point Assessment", "level": "Level 5" },
-        { "name": "Golf Greenkeeper", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Greek", "qualType": "GCSE", "level": "Level 2" },
-        { "name": "Greek", "qualType": "A Level", "level": "Level 3" },
-        { "name": "Greek", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Groundworker", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Gujarati", "qualType": "GCSE", "level": "Level 2" },
-        { "name": "Gujarati", "qualType": "A Level", "level": "Level 3" },
-        { "name": "Gujarati", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Hair Professional", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Hairdressing, Barbering and Beauty Therapy", "qualType": "T Level", "level": "Level 3" },
-        { "name": "Harbour Master", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Health", "qualType": "T Level", "level": "Level 3" },
-        { "name": "Health and Care Intelligence Specialist", "qualType": "End-Point Assessment", "level": "Level 7" },
-        { "name": "Health and social care", "qualType": "A Level", "level": "Level 3" },
-        { "name": "Health and social care", "qualType": "AS Level", "level": "Level 3" },
-        { "name": "Health and social care", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Health Play Specialist", "qualType": "End-Point Assessment", "level": "Level 5" },
-        { "name": "Healthcare assistant practitioner", "qualType": "End-Point Assessment", "level": "Level 5" },
-        { "name": "Healthcare Cleaning Operative", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Healthcare engineering specialist technician", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Healthcare Science", "qualType": "T Level", "level": "Level 3" },
-        { "name": "Healthcare science assistant", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Healthcare science associate", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Healthcare Science Practitioner (Integrated Degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "healthcare support worker", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Hearing Aid Dispenser", "qualType": "End-Point Assessment", "level": "Level 5" },
-        { "name": "Heavy vehicle service and maintenance technician", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Heritage Engineering Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "High Speed Rail and Infrastructure Technician", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Highway Electrical Maintenance and Installation Operative", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Highways Electrician or Service Operative", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Highways Maintenance Skilled Operative", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Hire Controller (Plant, Tools and Equipment)", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Historic Environment Advice Assistant", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Historic Environment Advisor", "qualType": "End-Point Assessment", "level": "Level 7" },
-        { "name": "History", "qualType": "GCSE", "level": "Level 2" },
-        { "name": "History", "qualType": "A Level", "level": "Level 3" },
-        { "name": "History", "qualType": "AS Level", "level": "Level 3" },
-        { "name": "History", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "HM Forces Serviceperson (public services)", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Home economics", "qualType": "GCSE", "level": "Level 2" },
-        { "name": "Home economics", "qualType": "A Level", "level": "Level 3" },
-        { "name": "Home economics", "qualType": "AS Level", "level": "Level 3" },
-        { "name": "Home economics", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Horticulture and landscaping technical manager", "qualType": "End-Point Assessment", "level": "Level 5" },
-        { "name": "Horticulture Operative or Landscape", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Hospitality", "qualType": "GCSE", "level": "Level 2" },
-        { "name": "Hospitality", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Hospitality Manager", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Hospitality Supervisor", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Hospitality Team Member", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Housing and Property Management", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Housing and Property Management Assistant", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "HR consultant partner", "qualType": "End-Point Assessment", "level": "Level 5" },
-        { "name": "HR Support", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Hygiene Specialist", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "ICT", "qualType": "GCSE", "level": "Level 2" },
-        { "name": "ICT", "qualType": "A Level", "level": "Level 3" },
-        { "name": "ICT", "qualType": "AS Level", "level": "Level 3" },
-        { "name": "ICT", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Improvement leader", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Improvement practitioner", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Improvement specialist", "qualType": "End-Point Assessment", "level": "Level 5" },
-        { "name": "Improvement technician", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Industrial Coatings Applicator", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Industrial Thermal Insulation Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Information Communications Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Information Manager", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Installation Electrician and Maintenance Electrician", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Insurance practitioner", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Insurance Professional", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Intelligence Analyst", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Interior Systems Installer", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Internal Audit Practitioner", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Internal Audit Professional", "qualType": "End-Point Assessment", "level": "Level 7" },
-        { "name": "International Freight Forwarding Specialist", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Investment Operations Administrator", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Investment Operations Specialist", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Investment Operations Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Irish", "qualType": "GCSE", "level": "Level 2" },
-        { "name": "Irish", "qualType": "A Level", "level": "Level 3" },
-        { "name": "Irish", "qualType": "AS Level", "level": "Level 3" },
-        { "name": "Irish", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "IT solutions technician", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "IT Technical Salesperson", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Italian", "qualType": "GCSE", "level": "Level 2" },
-        { "name": "Italian", "qualType": "A Level", "level": "Level 3" },
-        { "name": "Italian", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Japanese", "qualType": "GCSE", "level": "Level 2" },
-        { "name": "Japanese", "qualType": "A Level", "level": "Level 3" },
-        { "name": "Japanese", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Jewellery, silversmithing, and allied trades professional", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Journalism", "qualType": "GCSE", "level": "Level 2" },
-        { "name": "Journalism", "qualType": "A Level", "level": "Level 3" },
-        { "name": "Journalism", "qualType": "AS Level", "level": "Level 3" },
-        { "name": "Journalism", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Journalist", "qualType": "End-Point Assessment", "level": "Level 5" },
-        { "name": "Junior 2D Artist  (visual effects)", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Junior advertising creative", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Junior Animator", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Junior Content Producer", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Junior Energy Manager", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Junior Estate Agent", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Junior Management Consultant", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Junior VFX Artist (Generalist)", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Keeper and aquarist", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Knitted product manufacturing technician", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Laboratory Scientist (degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Laboratory Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Land Based Service Engineer", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Land Referencer", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Land-based service engineering technician", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Landscape or Horticulture Supervisor", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Landscape Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Large Goods Vehicle( LGV) Driver C+E", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Latin", "qualType": "GCSE", "level": "Level 2" },
-        { "name": "Latin", "qualType": "A Level", "level": "Level 3" },
-        { "name": "Latin", "qualType": "AS Level", "level": "Level 3" },
-        { "name": "Latin", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Law", "qualType": "A Level", "level": "Level 3" },
-        { "name": "Law", "qualType": "AS Level", "level": "Level 3" },
-        { "name": "Law", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Lead adult care worker", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Lead Practitioner in Adult Care", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Leader in Adult Care", "qualType": "End-Point Assessment", "level": "Level 5" },
-        { "name": "Lean manufacturing operative", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Learning and development consultant business partner", "qualType": "End-Point Assessment", "level": "Level 5" },
-        { "name": "Learning and development practitioner", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Learning and Skills Teacher", "qualType": "End-Point Assessment", "level": "Level 5" },
-        { "name": "Learning Mentor", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Leather Craftsperson", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Legal Services", "qualType": "T Level", "level": "Level 3" },
-        { "name": "Leisure and tourism", "qualType": "GCSE", "level": "Level 2" },
-        { "name": "Leisure and tourism", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Leisure duty manager", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Leisure Team Member", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Level 5 Early Years Lead Practitioner", "qualType": "End-Point Assessment", "level": "Level 5" },
-        { "name": "Library, information & archive services assistant", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Licensed Conveyancer", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Life and health science", "qualType": "A Level", "level": "Level 3" },
-        { "name": "Life and health science", "qualType": "AS Level", "level": "Level 3" },
-        { "name": "Life and health science", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Lift and escalator electromechanic", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Lift Truck and Powered Access Engineering Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Lifting Equipment Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Lifting Technician", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Lightning Protection Operative", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Literature", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Live Event Rigger", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Live Event Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Livestock unit technician", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Maintenance and operations engineering technician", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Maintenance, Installation and Repair for Engineering and Manufacturing", "qualType": "T Level", "level": "Level 3" },
-        { "name": "Mammography Associate", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Management and Administration", "qualType": "T Level", "level": "Level 3" },
-        { "name": "Manufacturing engineer (degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Manufacturing Manager (integrated degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Marina and Boatyard Operative", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Marine electrician", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Marine engineer", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Marine Pilot", "qualType": "End-Point Assessment", "level": "Level 5" },
-        { "name": "Marine Surveyor (degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Marine technical superintendent (degree)", "qualType": "End-Point Assessment", "level": "Level 7" },
-        { "name": "Maritime Caterer", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Maritime mechanical and electrical mechanic", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Market research executive", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Marketing Assistant", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Marketing Executive", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Marketing Manager", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Mastic Asphalter", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Material cutter", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Materials process engineer (degree)", "qualType": "End-Point Assessment", "level": "Level 7" },
-        { "name": "Materials Science Technologist (Degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Mathematics", "qualType": "GCSE", "level": "Level 2" },
-        { "name": "Mathematics", "qualType": "A Level", "level": "Level 3" },
-        { "name": "Mathematics", "qualType": "AS Level", "level": "Level 3" },
-        { "name": "Mathematics", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Media", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Media Production Co-ordinator", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Media studies", "qualType": "GCSE", "level": "Level 2" },
-        { "name": "Media studies", "qualType": "A Level", "level": "Level 3" },
-        { "name": "Media studies", "qualType": "AS Level", "level": "Level 3" },
-        { "name": "Media studies", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Media, Broadcast and Production", "qualType": "T Level", "level": "Level 3" },
-        { "name": "Medical Statistician", "qualType": "End-Point Assessment", "level": "Level 7" },
-        { "name": "Metal casting, foundry and patternmaking technician", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Metal Fabricator", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Metal Recycling General Operative", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Metal Recycling Technical Manager (MRTM)", "qualType": "End-Point Assessment", "level": "Level 5" },
-        { "name": "Metrology Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Midwife", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Midwife (2019 NMC standards) (degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Military Engineering Construction Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Mineral and Construction Product Sampling and Testing Operations", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Mineral processing mobile and static plant operator", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Mineral Processing Weighbridge Operator", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Mineral Products Technician", "qualType": "End-Point Assessment", "level": "Level 5" },
-        { "name": "Modern Hebrew", "qualType": "GCSE", "level": "Level 2" },
-        { "name": "Modern Hebrew", "qualType": "A Level", "level": "Level 3" },
-        { "name": "Modern Hebrew", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Mortgage Adviser", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Motor Finance Specialist", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Motor Vehicle Service and Maintenance Technician (Light Vehicle)", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Motor vehicle studies", "qualType": "GCSE", "level": "Level 2" },
-        { "name": "Motor vehicle studies", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Motorcycle technician (repair and maintenance)", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Moving image arts", "qualType": "GCSE", "level": "Level 2" },
-        { "name": "Moving image arts", "qualType": "A Level", "level": "Level 3" },
-        { "name": "Moving image arts", "qualType": "AS Level", "level": "Level 3" },
-        { "name": "Moving image arts", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Museums and Galleries Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Music", "qualType": "GCSE", "level": "Level 2" },
-        { "name": "Music", "qualType": "A Level", "level": "Level 3" },
-        { "name": "Music", "qualType": "AS Level", "level": "Level 3" },
-        { "name": "Music", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Music technology", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Nail Services Technician", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Network Cable Installer", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Network Engineer", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Network Operations", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "New Furniture Product Developer", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Non-destructive testing (NDT) operator", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Non-destructive testing engineer (degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Non-destructive testing engineering technician", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Non-Home Office Police Officer", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Nuclear Health Physics Monitor", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Nuclear operative", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Nuclear reactor desk engineer", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Nuclear scientist and nuclear engineer (integrated degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Nuclear Technician", "qualType": "End-Point Assessment", "level": "Level 5" },
-        { "name": "Nuclear welding inspection technician", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "NULL", "qualType": "A Level", "level": "Level 3" },
-        { "name": "NULL", "qualType": "AS Level", "level": "Level 3" },
-        { "name": "NULL", "qualType": "AS Level", "level": "Level 3" },
-        { "name": "Nursing associate (NMC 2018)", "qualType": "End-Point Assessment", "level": "Level 5" },
-        { "name": "Occupational Therapist (Integrated Degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Officer of the watch (near coastal)", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Onsite Construction", "qualType": "T Level", "level": "Level 3" },
-        { "name": "Operating Department Practitioner (Integrated Degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Operational firefighter", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Operational Research Specialist", "qualType": "End-Point Assessment", "level": "Level 7" },
-        { "name": "Operations or departmental manager", "qualType": "End-Point Assessment", "level": "Level 5" },
-        { "name": "Optical Assistant", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Oral Health Practitioner", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Ordnance munitions and explosives (OME) professional (integrated degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Ordnance Munitions and Explosives Specialist  (integrated degree)", "qualType": "End-Point Assessment", "level": "Level 7" },
-        { "name": "Ordnance Munitions Explosives Technician", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Organ builder", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Orthodontic therapist (integrated)", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Outdoor Activity Instructor", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Outside broadcasting engineer (integrated degree)", "qualType": "End-Point Assessment", "level": "Level 7" },
-        { "name": "Packaging professional (integrated degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Packhouse Line Leader", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Painter and Decorator", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Panjabi", "qualType": "GCSE", "level": "Level 2" },
-        { "name": "Panjabi", "qualType": "A Level", "level": "Level 3" },
-        { "name": "Panjabi", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Papermaker", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Paralegal", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Paramedic (integrated degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Paraplanner", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Passenger transport driver - bus, coach and tram", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Passenger Transport Operations Manager", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Passenger transport operative", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Payroll Administrator", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Payroll Assistant Manager", "qualType": "End-Point Assessment", "level": "Level 5" },
-        { "name": "Performing arts", "qualType": "A Level", "level": "Level 3" },
-        { "name": "Performing arts", "qualType": "AS Level", "level": "Level 3" },
-        { "name": "Performing arts", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Persian", "qualType": "GCSE", "level": "Level 2" },
-        { "name": "Persian", "qualType": "A Level", "level": "Level 3" },
-        { "name": "Persian", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Personal  Trainer", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Pest Control Technician", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Pharmacy services assistant", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Pharmacy Technician (Integrated)", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Philosophy", "qualType": "A Level", "level": "Level 3" },
-        { "name": "Philosophy", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Photographic Assistant", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Photography", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Physical education", "qualType": "GCSE", "level": "Level 2" },
-        { "name": "Physical education", "qualType": "A Level", "level": "Level 3" },
-        { "name": "Physical education", "qualType": "AS Level", "level": "Level 3" },
-        { "name": "Physical education", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Physician Associate", "qualType": "End-Point Assessment", "level": "Level 7" },
-        { "name": "Physics", "qualType": "GCSE", "level": "Level 2" },
-        { "name": "Physics", "qualType": "A Level", "level": "Level 3" },
-        { "name": "Physics", "qualType": "AS Level", "level": "Level 3" },
-        { "name": "Physics", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Physiotherapist (Integrated Degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Piling Attendant", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Pipe Welder", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Plasterer", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Plate Welder", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Play therapist", "qualType": "End-Point Assessment", "level": "Level 7" },
-        { "name": "Plumbing and Domestic Heating Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Podiatrist (integrated degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Police Community Support Officer", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Police Constable (integrated degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Policy Officer", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Polish", "qualType": "GCSE", "level": "Level 2" },
-        { "name": "Polish", "qualType": "A Level", "level": "Level 3" },
-        { "name": "Polish", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Political studies", "qualType": "GCSE", "level": "Level 2" },
-        { "name": "Political studies", "qualType": "A Level", "level": "Level 3" },
-        { "name": "Political studies", "qualType": "AS Level", "level": "Level 3" },
-        { "name": "Political studies", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Port Marine Operations Officer", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Port operative", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Portuguese", "qualType": "GCSE", "level": "Level 2" },
-        { "name": "Portuguese", "qualType": "A Level", "level": "Level 3" },
-        { "name": "Portuguese", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Post graduate engineer", "qualType": "End-Point Assessment", "level": "Level 7" },
-        { "name": "Post Production Engineer", "qualType": "End-Point Assessment", "level": "Level 5" },
-        { "name": "Post- Production Technical Operator", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Poultry Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Poultry Worker", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Power and Propulsion Gas Turbine Engineer", "qualType": "End-Point Assessment", "level": "Level 7" },
-        { "name": "Power Network Craftsperson", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Powered Pedestrian Door Installer and Service Engineer", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Preparation for life and work", "qualType": "GCSE", "level": "Level 2" },
-        { "name": "Preparation for life and work", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Print operative", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Print Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Probate Technician", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Process automation engineer (degree)", "qualType": "End-Point Assessment", "level": "Level 7" },
-        { "name": "Process leader", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Procurement and supply assistant", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Product design and development engineer (degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Production arts", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Production Chef", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Professional Accounting or Taxation Technician", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Professional Arboriculturist", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Professional economist (integrated degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Professional Forester", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Project", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Project controls professional", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Project Controls Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Project Manager (integrated degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Property Maintenance Operative", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Props Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Propulsion Technician", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Prosthetic and Orthotic technician", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Prosthetist and Orthotist (Integrated Degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Psychological Wellbeing Practitioner (PWP)", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Psychology", "qualType": "GCSE", "level": "Level 2" },
-        { "name": "Psychology", "qualType": "A Level", "level": "Level 3" },
-        { "name": "Psychology", "qualType": "AS Level", "level": "Level 3" },
-        { "name": "Psychology", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Public health practitioner (integrated degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Public relations and communications assistant", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Public sector compliance Investigator and officer", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Public Service Operational Delivery Officer", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Publishing Assistant", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Quality Practitioner", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Radio Network Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Rail  engineering  advanced technician", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Rail & Rail Systems Senior Engineer (integrated degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Rail and Rail Systems Engineer", "qualType": "End-Point Assessment", "level": "Level 5" },
-        { "name": "Rail and rail systems principal engineer (integrated degree)", "qualType": "End-Point Assessment", "level": "Level 7" },
-        { "name": "Rail Engineering Operative", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Rail Engineering Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Rail Infrastructure Operator", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Railway Engineering Design Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Recruitment Consultant", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Recruitment Resourcer", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Refrigeration air conditioning and heat pump engineering technician", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Registered Nurse  - Degree (NMC 2010)", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Registered Nurse Degree (NMC 2018)", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Registrar (Creative and Cultural)", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Regulatory Affairs Specialist", "qualType": "End-Point Assessment", "level": "Level 7" },
-        { "name": "Regulatory Compliance Officer", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Rehabilitation Worker (Visual Impairment)", "qualType": "End-Point Assessment", "level": "Level 5" },
-        { "name": "Religious", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Religious studies", "qualType": "GCSE", "level": "Level 2" },
-        { "name": "Religious studies", "qualType": "A Level", "level": "Level 3" },
-        { "name": "Religious studies", "qualType": "AS Level", "level": "Level 3" },
-        { "name": "Religious studies", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Research scientist", "qualType": "End-Point Assessment", "level": "Level 7" },
-        { "name": "Retail leadership degree apprenticeship", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Retail Manager", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Retail Team Leader", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Retailer", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Revenues and Welfare Benefits Practitioner", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Risk and safety management professional (degree)", "qualType": "End-Point Assessment", "level": "Level 7" },
-        { "name": "Road surfacing operative", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Road Transport engineering manager", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Roofer", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Russian", "qualType": "GCSE", "level": "Level 2" },
-        { "name": "Russian", "qualType": "A Level", "level": "Level 3" },
-        { "name": "Russian", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Safety, health and environment technician", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Sales Executive", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Scaffolder", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "School Business Professional", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Science", "qualType": "GCSE", "level": "Level 2" },
-        { "name": "Science", "qualType": "T Level", "level": "Level 3" },
-        { "name": "Science", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Science Industry Maintenance Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Science industry process and plant engineer (degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Science manufacturing process operative", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Science Manufacturing Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Seafarer (Deck Rating)", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Security First Line Manager", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Senior and head of facilities management (integrated degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Senior compliance and risk specialist", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Senior Culinary Chef", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Senior Equine Groom", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Senior financial services customer adviser", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Senior Healthcare Support Worker", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Senior housing and property management", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Senior Insurance Professional", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Senior investment and commercial banking professional", "qualType": "End-Point Assessment", "level": "Level 7" },
-        { "name": "Senior Journalist", "qualType": "End-Point Assessment", "level": "Level 7" },
-        { "name": "Senior Leader", "qualType": "End-Point Assessment", "level": "Level 7" },
-        { "name": "Senior Metrology Technician", "qualType": "End-Point Assessment", "level": "Level 5" },
-        { "name": "Senior People Professional", "qualType": "End-Point Assessment", "level": "Level 7" },
-        { "name": "Senior Production Chef", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Senior professional economist (integrated degree)", "qualType": "End-Point Assessment", "level": "Level 7" },
-        { "name": "Serious and complex crime investigator (integrated degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Sewing machinist", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Signage technician", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Smart Home Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Social worker (integrated degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Sociology", "qualType": "GCSE", "level": "Level 2" },
-        { "name": "Sociology", "qualType": "A Level", "level": "Level 3" },
-        { "name": "Sociology", "qualType": "AS Level", "level": "Level 3" },
-        { "name": "Sociology", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Software Developer", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Software Development Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Software Tester", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Solicitor", "qualType": "End-Point Assessment", "level": "Level 7" },
-        { "name": "Sonographer (Integrated degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Space Engineering Technician", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Spanish", "qualType": "GCSE", "level": "Level 2" },
-        { "name": "Spanish", "qualType": "A Level", "level": "Level 3" },
-        { "name": "Spanish", "qualType": "AS Level", "level": "Level 3" },
-        { "name": "Spanish", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Specialist community and public health nurse", "qualType": "End-Point Assessment", "level": "Level 7" },
-        { "name": "Specialist Rescue Operative", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Specialist Tyre Operative", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Spectacle maker", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Speech and Language Therapist (Integrated Degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Sport", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Sporting Excellence Professional", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Sports coach", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Sports Turf Operative", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Stained glass craftsperson", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Stairlift, Platform Lift, Service Lift Electromechanic", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Statistics", "qualType": "GCSE", "level": "Level 2" },
-        { "name": "Statistics", "qualType": "A Level", "level": "Level 3" },
-        { "name": "Statistics", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Steel fixer", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Stonemason", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Storyboard Artist", "qualType": "End-Point Assessment", "level": "Level 7" },
-        { "name": "Structural Steelwork Erector", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Structural Steelwork Fabricator", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Supply chain leadership professional (integrated degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Supply Chain Operator", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Supply Chain Practitioner (Fast Moving Consumer Good)", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Supply Chain Warehouse Operative", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Surveying Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Survival equipment fitter", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Sustainability business specialist  (integrated degree)", "qualType": "End-Point Assessment", "level": "Level 7" },
-        { "name": "Systems Engineer", "qualType": "End-Point Assessment", "level": "Level 7" },
-        { "name": "Systems Thinking Practitioner", "qualType": "End-Point Assessment", "level": "Level 7" },
-        { "name": "Teacher", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Teaching Assistant", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Team Leader or supervisor", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Technical dyer and colourist", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Technician Scientist", "qualType": "End-Point Assessment", "level": "Level 5" },
-        { "name": "Telecoms Field Operative", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Textile care operative", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Textile Manufacturing Operative", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Textile Technical Specialist", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Theatre", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Therapeutic Radiographer (Integrated Degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Through life engineering services specialist (integrated degree)", "qualType": "End-Point Assessment", "level": "Level 7" },
-        { "name": "Tool process design engineer", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Town Planning Assistant", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Trade Supplier", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Trade Union Official", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Train Driver", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Tramway Construction Operative", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Transport Planner (Integrated Degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "Transport Planning Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Travel and Tourism", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Travel Consultant", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Tunnelling Operative", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Turkish", "qualType": "GCSE", "level": "Level 2" },
-        { "name": "Turkish", "qualType": "A Level", "level": "Level 3" },
-        { "name": "Turkish", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Underkeeper", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Unified Communications Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Urban Driver", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Urdu", "qualType": "GCSE", "level": "Level 2" },
-        { "name": "Urdu", "qualType": "A Level", "level": "Level 3" },
-        { "name": "Urdu", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Utilities engineering technician", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Vehicle Damage Assessor", "qualType": "End-Point Assessment", "level": "Level 4" },
-        { "name": "Vehicle damage mechanical electrical and trim (MET) technician", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Vehicle Damage Paint Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Vehicle Damage Panel Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Vet technician (livestock)", "qualType": "End-Point Assessment", "level": "Level 5" },
-        { "name": "Veterinary Nurse", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "VFX artist or technical director", "qualType": "End-Point Assessment", "level": "Level 6" },
-        { "name": "VFX Supervisor", "qualType": "End-Point Assessment", "level": "Level 7" },
-        { "name": "Wall and Floor Tiler", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Waste Resource Operative", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Watchmaker", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Water Environment Worker", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Water network operative", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Water process operative", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Water process technician", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Water treatment technician", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Wellbeing  and holistic Therapist", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Welsh second language", "qualType": "A Level", "level": "Level 3" },
-        { "name": "Welsh second language", "qualType": "AS Level", "level": "Level 3" },
-        { "name": "Welsh second language", "qualType": "Other qualification type", "level": "Other qualification level" },
-        { "name": "Wireless Communications Rigger", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Wood product manufacturing operative", "qualType": "End-Point Assessment", "level": "Level 2" },
-        { "name": "Workboat Crewmember", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Workplace Pensions (Administrator or Consultant)", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Youth justice practitioner", "qualType": "End-Point Assessment", "level": "Level 5" },
-        { "name": "Youth support worker", "qualType": "End-Point Assessment", "level": "Level 3" },
-        { "name": "Youth worker", "qualType": "End-Point Assessment", "level": "Level 6" }
-      ]
+    {
+        "id": 0,
+        "name": "Abattoir Worker",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 1,
+        "name": "Academic Professional",
+        "qualType": "End-Point Assessment",
+        "level": "Level 7"
+    },
+    {
+        "id": 2,
+        "name": "Accident repair technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 3,
+        "name": "Accountancy or taxation professional",
+        "qualType": "End-Point Assessment",
+        "level": "Level 7"
+    },
+    {
+        "id": 4,
+        "name": "Accounting",
+        "qualType": "A Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 5,
+        "name": "Accounting",
+        "qualType": "T Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 6,
+        "name": "Accounting",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 7,
+        "name": "Accounts or finance assistant",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 8,
+        "name": "Acoustics Technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 9,
+        "name": "Actuarial Technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 10,
+        "name": "Actuary",
+        "qualType": "End-Point Assessment",
+        "level": "Level 7"
+    },
+    {
+        "id": 11,
+        "name": "Additional mathematics",
+        "qualType": "GCSE",
+        "level": "Level 2"
+    },
+    {
+        "id": 12,
+        "name": "Additional mathematics",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 13,
+        "name": "Adult Care Worker",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 14,
+        "name": "Advanced and Creative Hair Professional",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 15,
+        "name": "Advanced Beauty Therapist",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 16,
+        "name": "Advanced Butcher",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 17,
+        "name": "Advanced Carpentry and Joinery",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 18,
+        "name": "Advanced clinical practitioner (integrated degree)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 7"
+    },
+    {
+        "id": 19,
+        "name": "Advanced credit controller and Debt collection specialist",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 20,
+        "name": "Advanced Dairy Technologist",
+        "qualType": "End-Point Assessment",
+        "level": "Level 5"
+    },
+    {
+        "id": 21,
+        "name": "Advanced Forensic Practitioner (Custody or Sexual Offence)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 7"
+    },
+    {
+        "id": 22,
+        "name": "Advanced Furniture CNC Technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 23,
+        "name": "Advanced Golf Greenkeeper",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 24,
+        "name": "Advanced Upholsterer",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 25,
+        "name": "Advertising and Media Executive",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 26,
+        "name": "Aerospace engineer (degree)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 27,
+        "name": "Aerospace software development engineer (degree)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 28,
+        "name": "Agriculture",
+        "qualType": "GCSE",
+        "level": "Level 2"
+    },
+    {
+        "id": 29,
+        "name": "Agriculture",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 30,
+        "name": "Agriculture or horticulture professional adviser",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 31,
+        "name": "Agriculture, Land Management and Production",
+        "qualType": "T Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 32,
+        "name": "Air Traffic Controller",
+        "qualType": "End-Point Assessment",
+        "level": "Level 5"
+    },
+    {
+        "id": 33,
+        "name": "Aircraft Certifying Technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 34,
+        "name": "Ambulance Support Worker (emergency, urgent, and non-urgent)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 35,
+        "name": "Ancient history",
+        "qualType": "GCSE",
+        "level": "Level 2"
+    },
+    {
+        "id": 36,
+        "name": "Ancient history",
+        "qualType": "A Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 37,
+        "name": "Ancient history",
+        "qualType": "AS Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 38,
+        "name": "Ancient history",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 39,
+        "name": "Animal Care and Management",
+        "qualType": "T Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 40,
+        "name": "Animal Care and Welfare Assistant",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 41,
+        "name": "Animal Technologist",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 42,
+        "name": "Animal Trainer",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 43,
+        "name": "Animation",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 44,
+        "name": "Anti-Social Behaviour and Community Safety Officer",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 45,
+        "name": "Applications support lead",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 46,
+        "name": "Applied Biology",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 47,
+        "name": "Applied Psychology",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 48,
+        "name": "Applied Science",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 49,
+        "name": "Arabic",
+        "qualType": "GCSE",
+        "level": "Level 2"
+    },
+    {
+        "id": 50,
+        "name": "Arabic",
+        "qualType": "A Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 51,
+        "name": "Arabic",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 52,
+        "name": "Arboriculturist",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 53,
+        "name": "Arborist",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 54,
+        "name": "Archaeological specialist (Degree)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 7"
+    },
+    {
+        "id": 55,
+        "name": "Archaeological Technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 56,
+        "name": "Architect (integrated degree)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 7"
+    },
+    {
+        "id": 57,
+        "name": "Architectural assistant (integrated degree)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 58,
+        "name": "Archivist and Records Manager",
+        "qualType": "End-Point Assessment",
+        "level": "Level 7"
+    },
+    {
+        "id": 59,
+        "name": "Art",
+        "qualType": "GCSE",
+        "level": "Level 2"
+    },
+    {
+        "id": 60,
+        "name": "Art",
+        "qualType": "A Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 61,
+        "name": "Art",
+        "qualType": "AS Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 62,
+        "name": "Art",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 63,
+        "name": "Art: 3D studies",
+        "qualType": "GCSE",
+        "level": "Level 2"
+    },
+    {
+        "id": 64,
+        "name": "Art: 3D studies",
+        "qualType": "A Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 65,
+        "name": "Art: 3D studies",
+        "qualType": "AS Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 66,
+        "name": "Art: 3D studies",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 67,
+        "name": "Art: Crafts",
+        "qualType": "GCSE",
+        "level": "Level 2"
+    },
+    {
+        "id": 68,
+        "name": "Art: Crafts",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 69,
+        "name": "Art: Critical studies",
+        "qualType": "GCSE",
+        "level": "Level 2"
+    },
+    {
+        "id": 70,
+        "name": "Art: Critical studies",
+        "qualType": "A Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 71,
+        "name": "Art: Critical studies",
+        "qualType": "AS Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 72,
+        "name": "Art: Critical studies",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 73,
+        "name": "Art: Fine art",
+        "qualType": "GCSE",
+        "level": "Level 2"
+    },
+    {
+        "id": 74,
+        "name": "Art: Fine art",
+        "qualType": "A Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 75,
+        "name": "Art: Fine art",
+        "qualType": "AS Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 76,
+        "name": "Art: Fine art",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 77,
+        "name": "Art: Graphics",
+        "qualType": "GCSE",
+        "level": "Level 2"
+    },
+    {
+        "id": 78,
+        "name": "Art: Graphics",
+        "qualType": "A Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 79,
+        "name": "Art: Graphics",
+        "qualType": "AS Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 80,
+        "name": "Art: Graphics",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 81,
+        "name": "Art: History of art",
+        "qualType": "A Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 82,
+        "name": "Art: History of art",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 83,
+        "name": "Art: Photography",
+        "qualType": "GCSE",
+        "level": "Level 2"
+    },
+    {
+        "id": 84,
+        "name": "Art: Photography",
+        "qualType": "A Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 85,
+        "name": "Art: Photography",
+        "qualType": "AS Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 86,
+        "name": "Art: Photography",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 87,
+        "name": "Art: Textiles",
+        "qualType": "GCSE",
+        "level": "Level 2"
+    },
+    {
+        "id": 88,
+        "name": "Art: Textiles",
+        "qualType": "A Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 89,
+        "name": "Art: Textiles",
+        "qualType": "AS Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 90,
+        "name": "Art: Textiles",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 91,
+        "name": "Artificial Intelligence (AI) Data Specialist",
+        "qualType": "End-Point Assessment",
+        "level": "Level 7"
+    },
+    {
+        "id": 92,
+        "name": "Arts Therapist (Degree)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 7"
+    },
+    {
+        "id": 93,
+        "name": "Asbestos Analyst and Surveyor",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 94,
+        "name": "Assessor Coach",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 95,
+        "name": "Asset manager",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 96,
+        "name": "Assistant Accountant",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 97,
+        "name": "Assistant buyer and assistant merchandiser",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 98,
+        "name": "Assistant Puppet Maker",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 99,
+        "name": "Assistant recording technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 100,
+        "name": "Assistant technical director  (visual effects)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 101,
+        "name": "Associate Ambulance Practitioner",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 102,
+        "name": "Associate Continuing Healthcare Practitioner",
+        "qualType": "End-Point Assessment",
+        "level": "Level 5"
+    },
+    {
+        "id": 103,
+        "name": "Associate Project Manager",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 104,
+        "name": "Astronomy",
+        "qualType": "GCSE",
+        "level": "Level 2"
+    },
+    {
+        "id": 105,
+        "name": "Astronomy",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 106,
+        "name": "Autocare Technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 107,
+        "name": "Automation & Controls Engineering Technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 108,
+        "name": "Automotive Glazing Technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 109,
+        "name": "Aviation Customer Service",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 110,
+        "name": "Aviation Ground Handler",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 111,
+        "name": "Aviation ground operative (above wing)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 112,
+        "name": "Aviation Ground Specialist",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 113,
+        "name": "Aviation Maintenance Mechanic (Military)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 114,
+        "name": "Aviation movement specialist",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 115,
+        "name": "Aviation Operations Manager",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 116,
+        "name": "Baker",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 117,
+        "name": "Beauty and Make Up Consultant",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 118,
+        "name": "Beauty Therapist",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 119,
+        "name": "BEMS (Building energy management systems) controls engineer",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 120,
+        "name": "Bengali",
+        "qualType": "GCSE",
+        "level": "Level 2"
+    },
+    {
+        "id": 121,
+        "name": "Bengali",
+        "qualType": "A Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 122,
+        "name": "Bengali",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 123,
+        "name": "Bespoke Furniture Maker",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 124,
+        "name": "Bespoke Saddler",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 125,
+        "name": "Bespoke Tailor and Cutter",
+        "qualType": "End-Point Assessment",
+        "level": "Level 5"
+    },
+    {
+        "id": 126,
+        "name": "Biblical Hebrew",
+        "qualType": "GCSE",
+        "level": "Level 2"
+    },
+    {
+        "id": 127,
+        "name": "Biblical Hebrew",
+        "qualType": "A Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 128,
+        "name": "Biblical Hebrew",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 129,
+        "name": "Bicycle mechanic",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 130,
+        "name": "Bid and Proposal Co-ordinator",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 131,
+        "name": "Bioinformatics scientist",
+        "qualType": "End-Point Assessment",
+        "level": "Level 7"
+    },
+    {
+        "id": 132,
+        "name": "Biology",
+        "qualType": "GCSE",
+        "level": "Level 2"
+    },
+    {
+        "id": 133,
+        "name": "Biology",
+        "qualType": "A Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 134,
+        "name": "Biology",
+        "qualType": "AS Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 135,
+        "name": "Biology",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 136,
+        "name": "Blacksmith",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 137,
+        "name": "Boatbuilder",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 138,
+        "name": "Boatmaster",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 139,
+        "name": "Bookbinder",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 140,
+        "name": "Brewer",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 141,
+        "name": "Bricklayer",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 142,
+        "name": "Broadcast and Communications Technical Operator",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 143,
+        "name": "Broadcast and media systems engineer (integrated degree)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 144,
+        "name": "Broadcast and Media Systems Technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 5"
+    },
+    {
+        "id": 145,
+        "name": "Broadcast Production Assistant",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 146,
+        "name": "Building Control Surveyor (integrated degree)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 147,
+        "name": "Building services design engineer (degree)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 148,
+        "name": "Building Services Engineering Craftsperson",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 149,
+        "name": "Building Services Engineering Ductwork Craftsperson",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 150,
+        "name": "Building Services Engineering Ductwork installer",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 151,
+        "name": "Building Services Engineering for Construction",
+        "qualType": "T Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 152,
+        "name": "Building Services Engineering Installer",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 153,
+        "name": "Building Services Engineering Service & Maintenance Engineer",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 154,
+        "name": "Building Services Engineering Site Management",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 155,
+        "name": "Building Services Engineering Technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 156,
+        "name": "Building services engineering technician 2022",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 157,
+        "name": "Building services engineering ventilation hygiene technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 158,
+        "name": "Bus and Coach Engineering Technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 159,
+        "name": "Business",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 160,
+        "name": "Business Administrator",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 161,
+        "name": "Business Analyst",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 162,
+        "name": "Business and communication systems",
+        "qualType": "GCSE",
+        "level": "Level 2"
+    },
+    {
+        "id": 163,
+        "name": "Business and communication systems",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 164,
+        "name": "Business Fire Safety Advisor",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 165,
+        "name": "Business studies",
+        "qualType": "GCSE",
+        "level": "Level 2"
+    },
+    {
+        "id": 166,
+        "name": "Business studies",
+        "qualType": "A Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 167,
+        "name": "Business studies",
+        "qualType": "AS Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 168,
+        "name": "Business studies",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 169,
+        "name": "Business to Business Sales Professional (integrated degree)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 170,
+        "name": "Butcher",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 171,
+        "name": "Buying and merchandising assistant",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 172,
+        "name": "Cabin Crew",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 173,
+        "name": "Camera Prep Technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 174,
+        "name": "Career Development Professional",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 175,
+        "name": "Carpentry and Joinery",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 176,
+        "name": "Catering",
+        "qualType": "T Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 177,
+        "name": "Chartered Landscape Professional",
+        "qualType": "End-Point Assessment",
+        "level": "Level 7"
+    },
+    {
+        "id": 178,
+        "name": "Chartered Legal Executive",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 179,
+        "name": "Chartered Manager Degree Apprenticeship",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 180,
+        "name": "Chartered Surveyor",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 181,
+        "name": "Chartered Town Planner (Degree)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 7"
+    },
+    {
+        "id": 182,
+        "name": "Chef de partie",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 183,
+        "name": "Chemistry",
+        "qualType": "GCSE",
+        "level": "Level 2"
+    },
+    {
+        "id": 184,
+        "name": "Chemistry",
+        "qualType": "A Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 185,
+        "name": "Chemistry",
+        "qualType": "AS Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 186,
+        "name": "Chemistry",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 187,
+        "name": "Children, Young People and Families Manager",
+        "qualType": "End-Point Assessment",
+        "level": "Level 5"
+    },
+    {
+        "id": 188,
+        "name": "Children, Young People and Families Practitioner",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 189,
+        "name": "Chinese",
+        "qualType": "GCSE",
+        "level": "Level 2"
+    },
+    {
+        "id": 190,
+        "name": "Chinese",
+        "qualType": "A Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 191,
+        "name": "Chinese",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 192,
+        "name": "Church minister (integrated degree)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 193,
+        "name": "Citizenship studies",
+        "qualType": "GCSE",
+        "level": "Level 2"
+    },
+    {
+        "id": 194,
+        "name": "Citizenship studies",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 195,
+        "name": "Civil Engineer",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 196,
+        "name": "Civil Engineering Site Management",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 197,
+        "name": "Civil engineering technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 198,
+        "name": "Classical civilisation",
+        "qualType": "GCSE",
+        "level": "Level 2"
+    },
+    {
+        "id": 199,
+        "name": "Classical civilisation",
+        "qualType": "A Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 200,
+        "name": "Classical civilisation",
+        "qualType": "AS Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 201,
+        "name": "Classical civilisation",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 202,
+        "name": "Classical Greek",
+        "qualType": "GCSE",
+        "level": "Level 2"
+    },
+    {
+        "id": 203,
+        "name": "Classical Greek",
+        "qualType": "A Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 204,
+        "name": "Classical Greek",
+        "qualType": "AS Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 205,
+        "name": "Classical Greek",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 206,
+        "name": "Classics",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 207,
+        "name": "Clinical associate in psychology (CAP) (integrated degree)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 7"
+    },
+    {
+        "id": 208,
+        "name": "Clinical Coder",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 209,
+        "name": "Clinical dental technician (integrated)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 5"
+    },
+    {
+        "id": 210,
+        "name": "Clinical pharmacology scientist (integrated degree)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 7"
+    },
+    {
+        "id": 211,
+        "name": "Clinical Scientist",
+        "qualType": "End-Point Assessment",
+        "level": "Level 7"
+    },
+    {
+        "id": 212,
+        "name": "Clinical Trials Specialist",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 213,
+        "name": "Clock Maker",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 214,
+        "name": "Coaching Professional",
+        "qualType": "End-Point Assessment",
+        "level": "Level 5"
+    },
+    {
+        "id": 215,
+        "name": "Combined science",
+        "qualType": "GCSE",
+        "level": "Level 2"
+    },
+    {
+        "id": 216,
+        "name": "Combined science",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 217,
+        "name": "Commercial Catering Equipment Technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 218,
+        "name": "Commercial Procurement and Supply (formerly Public sector commercial professional)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 219,
+        "name": "Commercial Thermal Insulation Operative",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 220,
+        "name": "Commis chef",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 221,
+        "name": "Community Activator Coach",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 222,
+        "name": "Community Energy Specialist",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 223,
+        "name": "Community Health and Wellbeing Worker",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 224,
+        "name": "Community Safety Advisor",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 225,
+        "name": "Community Sport and Health Officer",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 226,
+        "name": "Compliance and risk officer",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 227,
+        "name": "Composites Technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 228,
+        "name": "Compressed air and vacuum technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 229,
+        "name": "Computing",
+        "qualType": "GCSE",
+        "level": "Level 2"
+    },
+    {
+        "id": 230,
+        "name": "Computing",
+        "qualType": "A Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 231,
+        "name": "Computing",
+        "qualType": "AS Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 232,
+        "name": "Computing",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 233,
+        "name": "Construction",
+        "qualType": "GCSE",
+        "level": "Level 2"
+    },
+    {
+        "id": 234,
+        "name": "Construction",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 235,
+        "name": "Construction Assembly and Installation Operative",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 236,
+        "name": "Construction Design and Build Technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 237,
+        "name": "Construction Equipment Maintenance Mechanic",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 238,
+        "name": "Construction Plant Operative",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 239,
+        "name": "Construction Quantity Surveying Technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 240,
+        "name": "Construction Quantity Surveyor",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 241,
+        "name": "Construction Site Engineering Technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 242,
+        "name": "Construction Site Management",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 243,
+        "name": "Construction Site Supervisor",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 244,
+        "name": "Construction Support Technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 245,
+        "name": "Control technical support engineer",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 246,
+        "name": "Conveyancing Technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 247,
+        "name": "Corporate responsibility and sustainability practitioner",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 248,
+        "name": "Costume Performance Technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 249,
+        "name": "Counter Fraud Investigator",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 250,
+        "name": "Countryside Ranger",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 251,
+        "name": "Countryside Worker",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 252,
+        "name": "Craft",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 253,
+        "name": "Craft and Design",
+        "qualType": "T Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 254,
+        "name": "Creative Digital",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 255,
+        "name": "Creative digital design professional (integrated degree)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 256,
+        "name": "Creative Digital Media",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 257,
+        "name": "Creative industries production manager  (degree)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 7"
+    },
+    {
+        "id": 258,
+        "name": "Creative Venue Technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 259,
+        "name": "Credit Controller and collector",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 260,
+        "name": "Crop Technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 261,
+        "name": "Cultural Heritage Conservation Technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 262,
+        "name": "Cultural Heritage Conservator",
+        "qualType": "End-Point Assessment",
+        "level": "Level 7"
+    },
+    {
+        "id": 263,
+        "name": "Cultural Learning & Participation Officer",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 264,
+        "name": "Curator",
+        "qualType": "End-Point Assessment",
+        "level": "Level 7"
+    },
+    {
+        "id": 265,
+        "name": "Curtain Wall Installer",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 266,
+        "name": "Custody & Detention Officer",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 267,
+        "name": "Customer Service Practitioner",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 268,
+        "name": "Customer Service Specialist",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 269,
+        "name": "Cyber Security Technical Professional (Integrated Degree)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 270,
+        "name": "Cyber Security Technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 271,
+        "name": "Cyber Security Technologist (2021)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 272,
+        "name": "Dance",
+        "qualType": "GCSE",
+        "level": "Level 2"
+    },
+    {
+        "id": 273,
+        "name": "Dance",
+        "qualType": "A Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 274,
+        "name": "Dance",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 275,
+        "name": "Dance Theatre",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 276,
+        "name": "Data Analyst",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 277,
+        "name": "Data Scientist (Integrated Degree)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 278,
+        "name": "Data Technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 279,
+        "name": "Debt Adviser",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 280,
+        "name": "Demolition Operative",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 281,
+        "name": "Dental Nurse",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 282,
+        "name": "Dental Practice Manager",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 283,
+        "name": "Dental Technician (Integrated)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 5"
+    },
+    {
+        "id": 284,
+        "name": "Design",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 285,
+        "name": "Design and Construction Management (Degree)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 286,
+        "name": "Design and Development for Engineering and Manufacturing",
+        "qualType": "T Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 287,
+        "name": "Design and technology",
+        "qualType": "GCSE",
+        "level": "Level 2"
+    },
+    {
+        "id": 288,
+        "name": "Design and technology",
+        "qualType": "A Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 289,
+        "name": "Design and technology",
+        "qualType": "AS Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 290,
+        "name": "Design and technology",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 291,
+        "name": "Design, Surveying and Planning for Construction",
+        "qualType": "T Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 292,
+        "name": "DevOps Engineer",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 293,
+        "name": "Diagnostic Radiographer (Integrated Degree)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 294,
+        "name": "Dietitian (integrated degree)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 295,
+        "name": "Digital Accessibility Specialist",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 296,
+        "name": "Digital and Technology Solutions Professional (integrated degree)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 297,
+        "name": "Digital and Technology Solutions Specialist (integrated degree)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 7"
+    },
+    {
+        "id": 298,
+        "name": "Digital Business Services",
+        "qualType": "T Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 299,
+        "name": "Digital Community Manager",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 300,
+        "name": "Digital Engineering Technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 301,
+        "name": "Digital Games",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 302,
+        "name": "Digital Marketer",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 303,
+        "name": "Digital marketer integrated degree",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 304,
+        "name": "Digital Media",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 305,
+        "name": "Digital Production, Design and Development",
+        "qualType": "T Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 306,
+        "name": "Digital Support Services",
+        "qualType": "T Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 307,
+        "name": "Digital Support Technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 308,
+        "name": "Digital User Experience (UX) Professional (Integrated Degree)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 309,
+        "name": "District Nurse",
+        "qualType": "End-Point Assessment",
+        "level": "Level 7"
+    },
+    {
+        "id": 310,
+        "name": "Dog groomer",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 311,
+        "name": "Drama",
+        "qualType": "GCSE",
+        "level": "Level 2"
+    },
+    {
+        "id": 312,
+        "name": "Drama",
+        "qualType": "A Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 313,
+        "name": "Drama",
+        "qualType": "AS Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 314,
+        "name": "Drama",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 315,
+        "name": "Drinks dispense technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 316,
+        "name": "Dual Fuel Smart Meter Installer",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 317,
+        "name": "Early intervention practitioner",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 318,
+        "name": "Early years educator",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 319,
+        "name": "Early Years Practitioner",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 320,
+        "name": "Ecologist",
+        "qualType": "End-Point Assessment",
+        "level": "Level 7"
+    },
+    {
+        "id": 321,
+        "name": "Economics",
+        "qualType": "GCSE",
+        "level": "Level 2"
+    },
+    {
+        "id": 322,
+        "name": "Economics",
+        "qualType": "A Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 323,
+        "name": "Economics",
+        "qualType": "AS Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 324,
+        "name": "Economics",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 325,
+        "name": "Education and Childcare",
+        "qualType": "T Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 326,
+        "name": "Education Technician (HE Assistant Technician & Simulation-based Technician)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 327,
+        "name": "Electrical Electronic Product Servicing and Installation Engineer",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 328,
+        "name": "Electrical or electronic technical support engineer (degree)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 329,
+        "name": "Electrical power networks engineer",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 330,
+        "name": "Electrical power protection and plant commissioning engineer",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 331,
+        "name": "Electro-mechanical engineer",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 332,
+        "name": "Electronic Systems Principal Engineer",
+        "qualType": "End-Point Assessment",
+        "level": "Level 7"
+    },
+    {
+        "id": 333,
+        "name": "Electronics",
+        "qualType": "GCSE",
+        "level": "Level 2"
+    },
+    {
+        "id": 334,
+        "name": "Electronics",
+        "qualType": "A Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 335,
+        "name": "Electronics",
+        "qualType": "AS Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 336,
+        "name": "Electronics",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 337,
+        "name": "Embedded electronic systems design and development engineer (degree)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 338,
+        "name": "Emergency Service Contact Handler",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 339,
+        "name": "Employability Practitioner",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 340,
+        "name": "Engineer Surveyor",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 341,
+        "name": "Engineering",
+        "qualType": "GCSE",
+        "level": "Level 2"
+    },
+    {
+        "id": 342,
+        "name": "Engineering",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 343,
+        "name": "Engineering construction erector rigger",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 344,
+        "name": "Engineering Construction Pipefitter",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 345,
+        "name": "Engineering design and draughtsperson",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 346,
+        "name": "Engineering fitter",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 347,
+        "name": "Engineering Manufacturing Technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 348,
+        "name": "Engineering Operative",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 349,
+        "name": "Engineering Technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 350,
+        "name": "Engineering, Manufacturing, Processing and Control",
+        "qualType": "T Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 351,
+        "name": "English language",
+        "qualType": "GCSE",
+        "level": "Level 2"
+    },
+    {
+        "id": 352,
+        "name": "English language",
+        "qualType": "A Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 353,
+        "name": "English language",
+        "qualType": "AS Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 354,
+        "name": "English language",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 355,
+        "name": "English language and literature",
+        "qualType": "A Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 356,
+        "name": "English language and literature",
+        "qualType": "AS Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 357,
+        "name": "English literature",
+        "qualType": "GCSE",
+        "level": "Level 2"
+    },
+    {
+        "id": 358,
+        "name": "English literature",
+        "qualType": "A Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 359,
+        "name": "English literature",
+        "qualType": "AS Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 360,
+        "name": "English literature",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 361,
+        "name": "Enhanced Clinical Practitioner",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 362,
+        "name": "Environmental health practitioner (integrated degree)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 363,
+        "name": "Environmental practitioner",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 364,
+        "name": "Environmental Science",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 365,
+        "name": "Environmental studies",
+        "qualType": "A Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 366,
+        "name": "Environmental studies",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 367,
+        "name": "Environmental technology",
+        "qualType": "A Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 368,
+        "name": "Environmental technology",
+        "qualType": "AS Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 369,
+        "name": "Environmental technology",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 370,
+        "name": "Equine groom",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 371,
+        "name": "Event Assistant",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 372,
+        "name": "Express delivery Manager",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 373,
+        "name": "Express delivery operative",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 374,
+        "name": "Express delivery sortation hub operative",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 375,
+        "name": "Facilities Management Supervisor",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 376,
+        "name": "Facilities Manager",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 377,
+        "name": "Facilities Services Operative",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 378,
+        "name": "Fall Protection Technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 379,
+        "name": "Farrier",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 380,
+        "name": "Fashion and Textiles Pattern Cutter",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 381,
+        "name": "Fashion and textiles product technologist",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 382,
+        "name": "Fashion Studio Assistant",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 383,
+        "name": "Fencing Installer",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 384,
+        "name": "Fenestration fabricator",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 385,
+        "name": "Fenestration Installer",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 386,
+        "name": "Film",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 387,
+        "name": "Film Studies",
+        "qualType": "GCSE",
+        "level": "Level 2"
+    },
+    {
+        "id": 388,
+        "name": "Film studies",
+        "qualType": "A Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 389,
+        "name": "Film studies",
+        "qualType": "AS Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 390,
+        "name": "Film studies",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 391,
+        "name": "Finance",
+        "qualType": "T Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 392,
+        "name": "Financial Advisor",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 393,
+        "name": "Financial Services Administrator",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 394,
+        "name": "Financial Services Customer Adviser",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 395,
+        "name": "Financial Services Professional",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 396,
+        "name": "Fire Emergency and Security Systems Technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 397,
+        "name": "Fire Safety Engineer (Degree)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 398,
+        "name": "Fire Safety Inspector",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 399,
+        "name": "First Officer Pilot",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 400,
+        "name": "Fisher",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 401,
+        "name": "Fishmonger",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 402,
+        "name": "Fitted Furniture Design Technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 403,
+        "name": "Floorlayer",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 404,
+        "name": "Florist",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 405,
+        "name": "Food",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 406,
+        "name": "Food and drink advanced engineer (integrated degree)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 407,
+        "name": "Food and Drink Engineer",
+        "qualType": "End-Point Assessment",
+        "level": "Level 5"
+    },
+    {
+        "id": 408,
+        "name": "Food and Drink Maintenance Engineer",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 409,
+        "name": "Food and drink process operator",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 410,
+        "name": "Food and drink technical operator",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 411,
+        "name": "Food industry technical professional (integrated degree)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 412,
+        "name": "Food preparation and nutrition",
+        "qualType": "GCSE",
+        "level": "Level 2"
+    },
+    {
+        "id": 413,
+        "name": "Food preparation and nutrition",
+        "qualType": "GCSE",
+        "level": "Level 2"
+    },
+    {
+        "id": 414,
+        "name": "Food preparation and nutrition",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 415,
+        "name": "Food Technologist",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 416,
+        "name": "Footwear manufacturer",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 417,
+        "name": "Forensic Collision Investigator",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 418,
+        "name": "Forest Operative",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 419,
+        "name": "Formworker",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 420,
+        "name": "French",
+        "qualType": "GCSE",
+        "level": "Level 2"
+    },
+    {
+        "id": 421,
+        "name": "French",
+        "qualType": "A Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 422,
+        "name": "French",
+        "qualType": "AS Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 423,
+        "name": "French",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 424,
+        "name": "Fundraiser",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 425,
+        "name": "Funeral Director",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 426,
+        "name": "Funeral Team Member",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 427,
+        "name": "Furniture Manufacturer",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 428,
+        "name": "Further mathematics",
+        "qualType": "GCSE",
+        "level": "Level 2"
+    },
+    {
+        "id": 429,
+        "name": "Further mathematics",
+        "qualType": "A Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 430,
+        "name": "Further mathematics",
+        "qualType": "AS Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 431,
+        "name": "Further mathematics",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 432,
+        "name": "Game programmer",
+        "qualType": "End-Point Assessment",
+        "level": "Level 7"
+    },
+    {
+        "id": 433,
+        "name": "Garment Maker",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 434,
+        "name": "Gas Engineering Operative",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 435,
+        "name": "Gas Network Craftsperson",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 436,
+        "name": "Gas Network Operative",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 437,
+        "name": "General farm worker",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 438,
+        "name": "General Welder (Arc Processes)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 439,
+        "name": "Geography",
+        "qualType": "GCSE",
+        "level": "Level 2"
+    },
+    {
+        "id": 440,
+        "name": "Geography",
+        "qualType": "A Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 441,
+        "name": "Geography",
+        "qualType": "AS Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 442,
+        "name": "Geography",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 443,
+        "name": "Geology",
+        "qualType": "GCSE",
+        "level": "Level 2"
+    },
+    {
+        "id": 444,
+        "name": "Geology",
+        "qualType": "A Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 445,
+        "name": "Geology",
+        "qualType": "AS Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 446,
+        "name": "Geology",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 447,
+        "name": "Geospatial Mapping and Science Specialist (Degree)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 448,
+        "name": "Geospatial Survey Technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 449,
+        "name": "Geotechnical engineer (integrated degree)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 7"
+    },
+    {
+        "id": 450,
+        "name": "German",
+        "qualType": "GCSE",
+        "level": "Level 2"
+    },
+    {
+        "id": 451,
+        "name": "German",
+        "qualType": "A Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 452,
+        "name": "German",
+        "qualType": "AS Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 453,
+        "name": "German",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 454,
+        "name": "Golf Course Manager",
+        "qualType": "End-Point Assessment",
+        "level": "Level 5"
+    },
+    {
+        "id": 455,
+        "name": "Golf Greenkeeper",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 456,
+        "name": "Greek",
+        "qualType": "GCSE",
+        "level": "Level 2"
+    },
+    {
+        "id": 457,
+        "name": "Greek",
+        "qualType": "A Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 458,
+        "name": "Greek",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 459,
+        "name": "Groundworker",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 460,
+        "name": "Gujarati",
+        "qualType": "GCSE",
+        "level": "Level 2"
+    },
+    {
+        "id": 461,
+        "name": "Gujarati",
+        "qualType": "A Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 462,
+        "name": "Gujarati",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 463,
+        "name": "Hair Professional",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 464,
+        "name": "Hairdressing, Barbering and Beauty Therapy",
+        "qualType": "T Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 465,
+        "name": "Harbour Master",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 466,
+        "name": "Health",
+        "qualType": "T Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 467,
+        "name": "Health and Care Intelligence Specialist",
+        "qualType": "End-Point Assessment",
+        "level": "Level 7"
+    },
+    {
+        "id": 468,
+        "name": "Health and social care",
+        "qualType": "A Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 469,
+        "name": "Health and social care",
+        "qualType": "AS Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 470,
+        "name": "Health and social care",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 471,
+        "name": "Health Play Specialist",
+        "qualType": "End-Point Assessment",
+        "level": "Level 5"
+    },
+    {
+        "id": 472,
+        "name": "Healthcare assistant practitioner",
+        "qualType": "End-Point Assessment",
+        "level": "Level 5"
+    },
+    {
+        "id": 473,
+        "name": "Healthcare Cleaning Operative",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 474,
+        "name": "Healthcare engineering specialist technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 475,
+        "name": "Healthcare Science",
+        "qualType": "T Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 476,
+        "name": "Healthcare science assistant",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 477,
+        "name": "Healthcare science associate",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 478,
+        "name": "Healthcare Science Practitioner (Integrated Degree)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 479,
+        "name": "healthcare support worker",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 480,
+        "name": "Hearing Aid Dispenser",
+        "qualType": "End-Point Assessment",
+        "level": "Level 5"
+    },
+    {
+        "id": 481,
+        "name": "Heavy vehicle service and maintenance technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 482,
+        "name": "Heritage Engineering Technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 483,
+        "name": "High Speed Rail and Infrastructure Technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 484,
+        "name": "Highway Electrical Maintenance and Installation Operative",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 485,
+        "name": "Highways Electrician or Service Operative",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 486,
+        "name": "Highways Maintenance Skilled Operative",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 487,
+        "name": "Hire Controller (Plant, Tools and Equipment)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 488,
+        "name": "Historic Environment Advice Assistant",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 489,
+        "name": "Historic Environment Advisor",
+        "qualType": "End-Point Assessment",
+        "level": "Level 7"
+    },
+    {
+        "id": 490,
+        "name": "History",
+        "qualType": "GCSE",
+        "level": "Level 2"
+    },
+    {
+        "id": 491,
+        "name": "History",
+        "qualType": "A Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 492,
+        "name": "History",
+        "qualType": "AS Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 493,
+        "name": "History",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 494,
+        "name": "HM Forces Serviceperson (public services)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 495,
+        "name": "Home economics",
+        "qualType": "GCSE",
+        "level": "Level 2"
+    },
+    {
+        "id": 496,
+        "name": "Home economics",
+        "qualType": "A Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 497,
+        "name": "Home economics",
+        "qualType": "AS Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 498,
+        "name": "Home economics",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 499,
+        "name": "Horticulture and landscaping technical manager",
+        "qualType": "End-Point Assessment",
+        "level": "Level 5"
+    },
+    {
+        "id": 500,
+        "name": "Horticulture Operative or Landscape",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 501,
+        "name": "Hospitality",
+        "qualType": "GCSE",
+        "level": "Level 2"
+    },
+    {
+        "id": 502,
+        "name": "Hospitality",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 503,
+        "name": "Hospitality Manager",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 504,
+        "name": "Hospitality Supervisor",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 505,
+        "name": "Hospitality Team Member",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 506,
+        "name": "Housing and Property Management",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 507,
+        "name": "Housing and Property Management Assistant",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 508,
+        "name": "HR consultant partner",
+        "qualType": "End-Point Assessment",
+        "level": "Level 5"
+    },
+    {
+        "id": 509,
+        "name": "HR Support",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 510,
+        "name": "Hygiene Specialist",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 511,
+        "name": "ICT",
+        "qualType": "GCSE",
+        "level": "Level 2"
+    },
+    {
+        "id": 512,
+        "name": "ICT",
+        "qualType": "A Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 513,
+        "name": "ICT",
+        "qualType": "AS Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 514,
+        "name": "ICT",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 515,
+        "name": "Improvement leader",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 516,
+        "name": "Improvement practitioner",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 517,
+        "name": "Improvement specialist",
+        "qualType": "End-Point Assessment",
+        "level": "Level 5"
+    },
+    {
+        "id": 518,
+        "name": "Improvement technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 519,
+        "name": "Industrial Coatings Applicator",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 520,
+        "name": "Industrial Thermal Insulation Technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 521,
+        "name": "Information Communications Technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 522,
+        "name": "Information Manager",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 523,
+        "name": "Installation Electrician and Maintenance Electrician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 524,
+        "name": "Insurance practitioner",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 525,
+        "name": "Insurance Professional",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 526,
+        "name": "Intelligence Analyst",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 527,
+        "name": "Interior Systems Installer",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 528,
+        "name": "Internal Audit Practitioner",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 529,
+        "name": "Internal Audit Professional",
+        "qualType": "End-Point Assessment",
+        "level": "Level 7"
+    },
+    {
+        "id": 530,
+        "name": "International Freight Forwarding Specialist",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 531,
+        "name": "Investment Operations Administrator",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 532,
+        "name": "Investment Operations Specialist",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 533,
+        "name": "Investment Operations Technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 534,
+        "name": "Irish",
+        "qualType": "GCSE",
+        "level": "Level 2"
+    },
+    {
+        "id": 535,
+        "name": "Irish",
+        "qualType": "A Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 536,
+        "name": "Irish",
+        "qualType": "AS Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 537,
+        "name": "Irish",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 538,
+        "name": "IT solutions technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 539,
+        "name": "IT Technical Salesperson",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 540,
+        "name": "Italian",
+        "qualType": "GCSE",
+        "level": "Level 2"
+    },
+    {
+        "id": 541,
+        "name": "Italian",
+        "qualType": "A Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 542,
+        "name": "Italian",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 543,
+        "name": "Japanese",
+        "qualType": "GCSE",
+        "level": "Level 2"
+    },
+    {
+        "id": 544,
+        "name": "Japanese",
+        "qualType": "A Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 545,
+        "name": "Japanese",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 546,
+        "name": "Jewellery, silversmithing, and allied trades professional",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 547,
+        "name": "Journalism",
+        "qualType": "GCSE",
+        "level": "Level 2"
+    },
+    {
+        "id": 548,
+        "name": "Journalism",
+        "qualType": "A Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 549,
+        "name": "Journalism",
+        "qualType": "AS Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 550,
+        "name": "Journalism",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 551,
+        "name": "Journalist",
+        "qualType": "End-Point Assessment",
+        "level": "Level 5"
+    },
+    {
+        "id": 552,
+        "name": "Junior 2D Artist  (visual effects)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 553,
+        "name": "Junior advertising creative",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 554,
+        "name": "Junior Animator",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 555,
+        "name": "Junior Content Producer",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 556,
+        "name": "Junior Energy Manager",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 557,
+        "name": "Junior Estate Agent",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 558,
+        "name": "Junior Management Consultant",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 559,
+        "name": "Junior VFX Artist (Generalist)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 560,
+        "name": "Keeper and aquarist",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 561,
+        "name": "Knitted product manufacturing technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 562,
+        "name": "Laboratory Scientist (degree)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 563,
+        "name": "Laboratory Technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 564,
+        "name": "Land Based Service Engineer",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 565,
+        "name": "Land Referencer",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 566,
+        "name": "Land-based service engineering technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 567,
+        "name": "Landscape or Horticulture Supervisor",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 568,
+        "name": "Landscape Technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 569,
+        "name": "Large Goods Vehicle( LGV) Driver C+E",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 570,
+        "name": "Latin",
+        "qualType": "GCSE",
+        "level": "Level 2"
+    },
+    {
+        "id": 571,
+        "name": "Latin",
+        "qualType": "A Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 572,
+        "name": "Latin",
+        "qualType": "AS Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 573,
+        "name": "Latin",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 574,
+        "name": "Law",
+        "qualType": "A Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 575,
+        "name": "Law",
+        "qualType": "AS Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 576,
+        "name": "Law",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 577,
+        "name": "Lead adult care worker",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 578,
+        "name": "Lead Practitioner in Adult Care",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 579,
+        "name": "Leader in Adult Care",
+        "qualType": "End-Point Assessment",
+        "level": "Level 5"
+    },
+    {
+        "id": 580,
+        "name": "Lean manufacturing operative",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 581,
+        "name": "Learning and development consultant business partner",
+        "qualType": "End-Point Assessment",
+        "level": "Level 5"
+    },
+    {
+        "id": 582,
+        "name": "Learning and development practitioner",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 583,
+        "name": "Learning and Skills Teacher",
+        "qualType": "End-Point Assessment",
+        "level": "Level 5"
+    },
+    {
+        "id": 584,
+        "name": "Learning Mentor",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 585,
+        "name": "Leather Craftsperson",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 586,
+        "name": "Legal Services",
+        "qualType": "T Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 587,
+        "name": "Leisure and tourism",
+        "qualType": "GCSE",
+        "level": "Level 2"
+    },
+    {
+        "id": 588,
+        "name": "Leisure and tourism",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 589,
+        "name": "Leisure duty manager",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 590,
+        "name": "Leisure Team Member",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 591,
+        "name": "Level 5 Early Years Lead Practitioner",
+        "qualType": "End-Point Assessment",
+        "level": "Level 5"
+    },
+    {
+        "id": 592,
+        "name": "Library, information & archive services assistant",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 593,
+        "name": "Licensed Conveyancer",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 594,
+        "name": "Life and health science",
+        "qualType": "A Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 595,
+        "name": "Life and health science",
+        "qualType": "AS Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 596,
+        "name": "Life and health science",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 597,
+        "name": "Lift and escalator electromechanic",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 598,
+        "name": "Lift Truck and Powered Access Engineering Technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 599,
+        "name": "Lifting Equipment Technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 600,
+        "name": "Lifting Technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 601,
+        "name": "Lightning Protection Operative",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 602,
+        "name": "Literature",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 603,
+        "name": "Live Event Rigger",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 604,
+        "name": "Live Event Technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 605,
+        "name": "Livestock unit technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 606,
+        "name": "Maintenance and operations engineering technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 607,
+        "name": "Maintenance, Installation and Repair for Engineering and Manufacturing",
+        "qualType": "T Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 608,
+        "name": "Mammography Associate",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 609,
+        "name": "Management and Administration",
+        "qualType": "T Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 610,
+        "name": "Manufacturing engineer (degree)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 611,
+        "name": "Manufacturing Manager (integrated degree)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 612,
+        "name": "Marina and Boatyard Operative",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 613,
+        "name": "Marine electrician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 614,
+        "name": "Marine engineer",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 615,
+        "name": "Marine Pilot",
+        "qualType": "End-Point Assessment",
+        "level": "Level 5"
+    },
+    {
+        "id": 616,
+        "name": "Marine Surveyor (degree)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 617,
+        "name": "Marine technical superintendent (degree)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 7"
+    },
+    {
+        "id": 618,
+        "name": "Maritime Caterer",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 619,
+        "name": "Maritime mechanical and electrical mechanic",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 620,
+        "name": "Market research executive",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 621,
+        "name": "Marketing Assistant",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 622,
+        "name": "Marketing Executive",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 623,
+        "name": "Marketing Manager",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 624,
+        "name": "Mastic Asphalter",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 625,
+        "name": "Material cutter",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 626,
+        "name": "Materials process engineer (degree)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 7"
+    },
+    {
+        "id": 627,
+        "name": "Materials Science Technologist (Degree)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 628,
+        "name": "Mathematics",
+        "qualType": "GCSE",
+        "level": "Level 2"
+    },
+    {
+        "id": 629,
+        "name": "Mathematics",
+        "qualType": "A Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 630,
+        "name": "Mathematics",
+        "qualType": "AS Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 631,
+        "name": "Mathematics",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 632,
+        "name": "Media",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 633,
+        "name": "Media Production Co-ordinator",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 634,
+        "name": "Media studies",
+        "qualType": "GCSE",
+        "level": "Level 2"
+    },
+    {
+        "id": 635,
+        "name": "Media studies",
+        "qualType": "A Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 636,
+        "name": "Media studies",
+        "qualType": "AS Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 637,
+        "name": "Media studies",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 638,
+        "name": "Media, Broadcast and Production",
+        "qualType": "T Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 639,
+        "name": "Medical Statistician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 7"
+    },
+    {
+        "id": 640,
+        "name": "Metal casting, foundry and patternmaking technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 641,
+        "name": "Metal Fabricator",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 642,
+        "name": "Metal Recycling General Operative",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 643,
+        "name": "Metal Recycling Technical Manager (MRTM)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 5"
+    },
+    {
+        "id": 644,
+        "name": "Metrology Technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 645,
+        "name": "Midwife",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 646,
+        "name": "Midwife (2019 NMC standards) (degree)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 647,
+        "name": "Military Engineering Construction Technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 648,
+        "name": "Mineral and Construction Product Sampling and Testing Operations",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 649,
+        "name": "Mineral processing mobile and static plant operator",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 650,
+        "name": "Mineral Processing Weighbridge Operator",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 651,
+        "name": "Mineral Products Technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 5"
+    },
+    {
+        "id": 652,
+        "name": "Modern Hebrew",
+        "qualType": "GCSE",
+        "level": "Level 2"
+    },
+    {
+        "id": 653,
+        "name": "Modern Hebrew",
+        "qualType": "A Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 654,
+        "name": "Modern Hebrew",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 655,
+        "name": "Mortgage Adviser",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 656,
+        "name": "Motor Finance Specialist",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 657,
+        "name": "Motor Vehicle Service and Maintenance Technician (Light Vehicle)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 658,
+        "name": "Motor vehicle studies",
+        "qualType": "GCSE",
+        "level": "Level 2"
+    },
+    {
+        "id": 659,
+        "name": "Motor vehicle studies",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 660,
+        "name": "Motorcycle technician (repair and maintenance)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 661,
+        "name": "Moving image arts",
+        "qualType": "GCSE",
+        "level": "Level 2"
+    },
+    {
+        "id": 662,
+        "name": "Moving image arts",
+        "qualType": "A Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 663,
+        "name": "Moving image arts",
+        "qualType": "AS Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 664,
+        "name": "Moving image arts",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 665,
+        "name": "Museums and Galleries Technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 666,
+        "name": "Music",
+        "qualType": "GCSE",
+        "level": "Level 2"
+    },
+    {
+        "id": 667,
+        "name": "Music",
+        "qualType": "A Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 668,
+        "name": "Music",
+        "qualType": "AS Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 669,
+        "name": "Music",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 670,
+        "name": "Music technology",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 671,
+        "name": "Nail Services Technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 672,
+        "name": "Network Cable Installer",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 673,
+        "name": "Network Engineer",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 674,
+        "name": "Network Operations",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 675,
+        "name": "New Furniture Product Developer",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 676,
+        "name": "Non-destructive testing (NDT) operator",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 677,
+        "name": "Non-destructive testing engineer (degree)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 678,
+        "name": "Non-destructive testing engineering technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 679,
+        "name": "Non-Home Office Police Officer",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 680,
+        "name": "Nuclear Health Physics Monitor",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 681,
+        "name": "Nuclear operative",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 682,
+        "name": "Nuclear reactor desk engineer",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 683,
+        "name": "Nuclear scientist and nuclear engineer (integrated degree)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 684,
+        "name": "Nuclear Technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 5"
+    },
+    {
+        "id": 685,
+        "name": "Nuclear welding inspection technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 686,
+        "name": "NULL",
+        "qualType": "A Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 687,
+        "name": "NULL",
+        "qualType": "AS Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 688,
+        "name": "NULL",
+        "qualType": "AS Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 689,
+        "name": "Nursing associate (NMC 2018)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 5"
+    },
+    {
+        "id": 690,
+        "name": "Occupational Therapist (Integrated Degree)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 691,
+        "name": "Officer of the watch (near coastal)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 692,
+        "name": "Onsite Construction",
+        "qualType": "T Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 693,
+        "name": "Operating Department Practitioner (Integrated Degree)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 694,
+        "name": "Operational firefighter",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 695,
+        "name": "Operational Research Specialist",
+        "qualType": "End-Point Assessment",
+        "level": "Level 7"
+    },
+    {
+        "id": 696,
+        "name": "Operations or departmental manager",
+        "qualType": "End-Point Assessment",
+        "level": "Level 5"
+    },
+    {
+        "id": 697,
+        "name": "Optical Assistant",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 698,
+        "name": "Oral Health Practitioner",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 699,
+        "name": "Ordnance munitions and explosives (OME) professional (integrated degree)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 700,
+        "name": "Ordnance Munitions and Explosives Specialist  (integrated degree)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 7"
+    },
+    {
+        "id": 701,
+        "name": "Ordnance Munitions Explosives Technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 702,
+        "name": "Organ builder",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 703,
+        "name": "Orthodontic therapist (integrated)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 704,
+        "name": "Outdoor Activity Instructor",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 705,
+        "name": "Outside broadcasting engineer (integrated degree)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 7"
+    },
+    {
+        "id": 706,
+        "name": "Packaging professional (integrated degree)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 707,
+        "name": "Packhouse Line Leader",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 708,
+        "name": "Painter and Decorator",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 709,
+        "name": "Panjabi",
+        "qualType": "GCSE",
+        "level": "Level 2"
+    },
+    {
+        "id": 710,
+        "name": "Panjabi",
+        "qualType": "A Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 711,
+        "name": "Panjabi",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 712,
+        "name": "Papermaker",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 713,
+        "name": "Paralegal",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 714,
+        "name": "Paramedic (integrated degree)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 715,
+        "name": "Paraplanner",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 716,
+        "name": "Passenger transport driver - bus, coach and tram",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 717,
+        "name": "Passenger Transport Operations Manager",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 718,
+        "name": "Passenger transport operative",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 719,
+        "name": "Payroll Administrator",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 720,
+        "name": "Payroll Assistant Manager",
+        "qualType": "End-Point Assessment",
+        "level": "Level 5"
+    },
+    {
+        "id": 721,
+        "name": "Performing arts",
+        "qualType": "A Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 722,
+        "name": "Performing arts",
+        "qualType": "AS Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 723,
+        "name": "Performing arts",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 724,
+        "name": "Persian",
+        "qualType": "GCSE",
+        "level": "Level 2"
+    },
+    {
+        "id": 725,
+        "name": "Persian",
+        "qualType": "A Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 726,
+        "name": "Persian",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 727,
+        "name": "Personal  Trainer",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 728,
+        "name": "Pest Control Technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 729,
+        "name": "Pharmacy services assistant",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 730,
+        "name": "Pharmacy Technician (Integrated)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 731,
+        "name": "Philosophy",
+        "qualType": "A Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 732,
+        "name": "Philosophy",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 733,
+        "name": "Photographic Assistant",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 734,
+        "name": "Photography",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 735,
+        "name": "Physical education",
+        "qualType": "GCSE",
+        "level": "Level 2"
+    },
+    {
+        "id": 736,
+        "name": "Physical education",
+        "qualType": "A Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 737,
+        "name": "Physical education",
+        "qualType": "AS Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 738,
+        "name": "Physical education",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 739,
+        "name": "Physician Associate",
+        "qualType": "End-Point Assessment",
+        "level": "Level 7"
+    },
+    {
+        "id": 740,
+        "name": "Physics",
+        "qualType": "GCSE",
+        "level": "Level 2"
+    },
+    {
+        "id": 741,
+        "name": "Physics",
+        "qualType": "A Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 742,
+        "name": "Physics",
+        "qualType": "AS Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 743,
+        "name": "Physics",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 744,
+        "name": "Physiotherapist (Integrated Degree)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 745,
+        "name": "Piling Attendant",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 746,
+        "name": "Pipe Welder",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 747,
+        "name": "Plasterer",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 748,
+        "name": "Plate Welder",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 749,
+        "name": "Play therapist",
+        "qualType": "End-Point Assessment",
+        "level": "Level 7"
+    },
+    {
+        "id": 750,
+        "name": "Plumbing and Domestic Heating Technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 751,
+        "name": "Podiatrist (integrated degree)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 752,
+        "name": "Police Community Support Officer",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 753,
+        "name": "Police Constable (integrated degree)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 754,
+        "name": "Policy Officer",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 755,
+        "name": "Polish",
+        "qualType": "GCSE",
+        "level": "Level 2"
+    },
+    {
+        "id": 756,
+        "name": "Polish",
+        "qualType": "A Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 757,
+        "name": "Polish",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 758,
+        "name": "Political studies",
+        "qualType": "GCSE",
+        "level": "Level 2"
+    },
+    {
+        "id": 759,
+        "name": "Political studies",
+        "qualType": "A Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 760,
+        "name": "Political studies",
+        "qualType": "AS Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 761,
+        "name": "Political studies",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 762,
+        "name": "Port Marine Operations Officer",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 763,
+        "name": "Port operative",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 764,
+        "name": "Portuguese",
+        "qualType": "GCSE",
+        "level": "Level 2"
+    },
+    {
+        "id": 765,
+        "name": "Portuguese",
+        "qualType": "A Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 766,
+        "name": "Portuguese",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 767,
+        "name": "Post graduate engineer",
+        "qualType": "End-Point Assessment",
+        "level": "Level 7"
+    },
+    {
+        "id": 768,
+        "name": "Post Production Engineer",
+        "qualType": "End-Point Assessment",
+        "level": "Level 5"
+    },
+    {
+        "id": 769,
+        "name": "Post- Production Technical Operator",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 770,
+        "name": "Poultry Technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 771,
+        "name": "Poultry Worker",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 772,
+        "name": "Power and Propulsion Gas Turbine Engineer",
+        "qualType": "End-Point Assessment",
+        "level": "Level 7"
+    },
+    {
+        "id": 773,
+        "name": "Power Network Craftsperson",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 774,
+        "name": "Powered Pedestrian Door Installer and Service Engineer",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 775,
+        "name": "Preparation for life and work",
+        "qualType": "GCSE",
+        "level": "Level 2"
+    },
+    {
+        "id": 776,
+        "name": "Preparation for life and work",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 777,
+        "name": "Print operative",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 778,
+        "name": "Print Technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 779,
+        "name": "Probate Technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 780,
+        "name": "Process automation engineer (degree)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 7"
+    },
+    {
+        "id": 781,
+        "name": "Process leader",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 782,
+        "name": "Procurement and supply assistant",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 783,
+        "name": "Product design and development engineer (degree)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 784,
+        "name": "Production arts",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 785,
+        "name": "Production Chef",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 786,
+        "name": "Professional Accounting or Taxation Technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 787,
+        "name": "Professional Arboriculturist",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 788,
+        "name": "Professional economist (integrated degree)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 789,
+        "name": "Professional Forester",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 790,
+        "name": "Project",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 791,
+        "name": "Project controls professional",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 792,
+        "name": "Project Controls Technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 793,
+        "name": "Project Manager (integrated degree)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 794,
+        "name": "Property Maintenance Operative",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 795,
+        "name": "Props Technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 796,
+        "name": "Propulsion Technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 797,
+        "name": "Prosthetic and Orthotic technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 798,
+        "name": "Prosthetist and Orthotist (Integrated Degree)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 799,
+        "name": "Psychological Wellbeing Practitioner (PWP)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 800,
+        "name": "Psychology",
+        "qualType": "GCSE",
+        "level": "Level 2"
+    },
+    {
+        "id": 801,
+        "name": "Psychology",
+        "qualType": "A Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 802,
+        "name": "Psychology",
+        "qualType": "AS Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 803,
+        "name": "Psychology",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 804,
+        "name": "Public health practitioner (integrated degree)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 805,
+        "name": "Public relations and communications assistant",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 806,
+        "name": "Public sector compliance Investigator and officer",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 807,
+        "name": "Public Service Operational Delivery Officer",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 808,
+        "name": "Publishing Assistant",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 809,
+        "name": "Quality Practitioner",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 810,
+        "name": "Radio Network Technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 811,
+        "name": "Rail  engineering  advanced technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 812,
+        "name": "Rail & Rail Systems Senior Engineer (integrated degree)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 813,
+        "name": "Rail and Rail Systems Engineer",
+        "qualType": "End-Point Assessment",
+        "level": "Level 5"
+    },
+    {
+        "id": 814,
+        "name": "Rail and rail systems principal engineer (integrated degree)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 7"
+    },
+    {
+        "id": 815,
+        "name": "Rail Engineering Operative",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 816,
+        "name": "Rail Engineering Technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 817,
+        "name": "Rail Infrastructure Operator",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 818,
+        "name": "Railway Engineering Design Technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 819,
+        "name": "Recruitment Consultant",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 820,
+        "name": "Recruitment Resourcer",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 821,
+        "name": "Refrigeration air conditioning and heat pump engineering technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 822,
+        "name": "Registered Nurse  - Degree (NMC 2010)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 823,
+        "name": "Registered Nurse Degree (NMC 2018)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 824,
+        "name": "Registrar (Creative and Cultural)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 825,
+        "name": "Regulatory Affairs Specialist",
+        "qualType": "End-Point Assessment",
+        "level": "Level 7"
+    },
+    {
+        "id": 826,
+        "name": "Regulatory Compliance Officer",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 827,
+        "name": "Rehabilitation Worker (Visual Impairment)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 5"
+    },
+    {
+        "id": 828,
+        "name": "Religious",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 829,
+        "name": "Religious studies",
+        "qualType": "GCSE",
+        "level": "Level 2"
+    },
+    {
+        "id": 830,
+        "name": "Religious studies",
+        "qualType": "A Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 831,
+        "name": "Religious studies",
+        "qualType": "AS Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 832,
+        "name": "Religious studies",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 833,
+        "name": "Research scientist",
+        "qualType": "End-Point Assessment",
+        "level": "Level 7"
+    },
+    {
+        "id": 834,
+        "name": "Retail leadership degree apprenticeship",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 835,
+        "name": "Retail Manager",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 836,
+        "name": "Retail Team Leader",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 837,
+        "name": "Retailer",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 838,
+        "name": "Revenues and Welfare Benefits Practitioner",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 839,
+        "name": "Risk and safety management professional (degree)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 7"
+    },
+    {
+        "id": 840,
+        "name": "Road surfacing operative",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 841,
+        "name": "Road Transport engineering manager",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 842,
+        "name": "Roofer",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 843,
+        "name": "Russian",
+        "qualType": "GCSE",
+        "level": "Level 2"
+    },
+    {
+        "id": 844,
+        "name": "Russian",
+        "qualType": "A Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 845,
+        "name": "Russian",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 846,
+        "name": "Safety, health and environment technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 847,
+        "name": "Sales Executive",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 848,
+        "name": "Scaffolder",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 849,
+        "name": "School Business Professional",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 850,
+        "name": "Science",
+        "qualType": "GCSE",
+        "level": "Level 2"
+    },
+    {
+        "id": 851,
+        "name": "Science",
+        "qualType": "T Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 852,
+        "name": "Science",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 853,
+        "name": "Science Industry Maintenance Technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 854,
+        "name": "Science industry process and plant engineer (degree)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 855,
+        "name": "Science manufacturing process operative",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 856,
+        "name": "Science Manufacturing Technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 857,
+        "name": "Seafarer (Deck Rating)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 858,
+        "name": "Security First Line Manager",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 859,
+        "name": "Senior and head of facilities management (integrated degree)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 860,
+        "name": "Senior compliance and risk specialist",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 861,
+        "name": "Senior Culinary Chef",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 862,
+        "name": "Senior Equine Groom",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 863,
+        "name": "Senior financial services customer adviser",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 864,
+        "name": "Senior Healthcare Support Worker",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 865,
+        "name": "Senior housing and property management",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 866,
+        "name": "Senior Insurance Professional",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 867,
+        "name": "Senior investment and commercial banking professional",
+        "qualType": "End-Point Assessment",
+        "level": "Level 7"
+    },
+    {
+        "id": 868,
+        "name": "Senior Journalist",
+        "qualType": "End-Point Assessment",
+        "level": "Level 7"
+    },
+    {
+        "id": 869,
+        "name": "Senior Leader",
+        "qualType": "End-Point Assessment",
+        "level": "Level 7"
+    },
+    {
+        "id": 870,
+        "name": "Senior Metrology Technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 5"
+    },
+    {
+        "id": 871,
+        "name": "Senior People Professional",
+        "qualType": "End-Point Assessment",
+        "level": "Level 7"
+    },
+    {
+        "id": 872,
+        "name": "Senior Production Chef",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 873,
+        "name": "Senior professional economist (integrated degree)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 7"
+    },
+    {
+        "id": 874,
+        "name": "Serious and complex crime investigator (integrated degree)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 875,
+        "name": "Sewing machinist",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 876,
+        "name": "Signage technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 877,
+        "name": "Smart Home Technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 878,
+        "name": "Social worker (integrated degree)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 879,
+        "name": "Sociology",
+        "qualType": "GCSE",
+        "level": "Level 2"
+    },
+    {
+        "id": 880,
+        "name": "Sociology",
+        "qualType": "A Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 881,
+        "name": "Sociology",
+        "qualType": "AS Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 882,
+        "name": "Sociology",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 883,
+        "name": "Software Developer",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 884,
+        "name": "Software Development Technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 885,
+        "name": "Software Tester",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 886,
+        "name": "Solicitor",
+        "qualType": "End-Point Assessment",
+        "level": "Level 7"
+    },
+    {
+        "id": 887,
+        "name": "Sonographer (Integrated degree)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 888,
+        "name": "Space Engineering Technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 889,
+        "name": "Spanish",
+        "qualType": "GCSE",
+        "level": "Level 2"
+    },
+    {
+        "id": 890,
+        "name": "Spanish",
+        "qualType": "A Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 891,
+        "name": "Spanish",
+        "qualType": "AS Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 892,
+        "name": "Spanish",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 893,
+        "name": "Specialist community and public health nurse",
+        "qualType": "End-Point Assessment",
+        "level": "Level 7"
+    },
+    {
+        "id": 894,
+        "name": "Specialist Rescue Operative",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 895,
+        "name": "Specialist Tyre Operative",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 896,
+        "name": "Spectacle maker",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 897,
+        "name": "Speech and Language Therapist (Integrated Degree)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 898,
+        "name": "Sport",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 899,
+        "name": "Sporting Excellence Professional",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 900,
+        "name": "Sports coach",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 901,
+        "name": "Sports Turf Operative",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 902,
+        "name": "Stained glass craftsperson",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 903,
+        "name": "Stairlift, Platform Lift, Service Lift Electromechanic",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 904,
+        "name": "Statistics",
+        "qualType": "GCSE",
+        "level": "Level 2"
+    },
+    {
+        "id": 905,
+        "name": "Statistics",
+        "qualType": "A Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 906,
+        "name": "Statistics",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 907,
+        "name": "Steel fixer",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 908,
+        "name": "Stonemason",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 909,
+        "name": "Storyboard Artist",
+        "qualType": "End-Point Assessment",
+        "level": "Level 7"
+    },
+    {
+        "id": 910,
+        "name": "Structural Steelwork Erector",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 911,
+        "name": "Structural Steelwork Fabricator",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 912,
+        "name": "Supply chain leadership professional (integrated degree)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 913,
+        "name": "Supply Chain Operator",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 914,
+        "name": "Supply Chain Practitioner (Fast Moving Consumer Good)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 915,
+        "name": "Supply Chain Warehouse Operative",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 916,
+        "name": "Surveying Technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 917,
+        "name": "Survival equipment fitter",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 918,
+        "name": "Sustainability business specialist  (integrated degree)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 7"
+    },
+    {
+        "id": 919,
+        "name": "Systems Engineer",
+        "qualType": "End-Point Assessment",
+        "level": "Level 7"
+    },
+    {
+        "id": 920,
+        "name": "Systems Thinking Practitioner",
+        "qualType": "End-Point Assessment",
+        "level": "Level 7"
+    },
+    {
+        "id": 921,
+        "name": "Teacher",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 922,
+        "name": "Teaching Assistant",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 923,
+        "name": "Team Leader or supervisor",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 924,
+        "name": "Technical dyer and colourist",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 925,
+        "name": "Technician Scientist",
+        "qualType": "End-Point Assessment",
+        "level": "Level 5"
+    },
+    {
+        "id": 926,
+        "name": "Telecoms Field Operative",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 927,
+        "name": "Textile care operative",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 928,
+        "name": "Textile Manufacturing Operative",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 929,
+        "name": "Textile Technical Specialist",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 930,
+        "name": "Theatre",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 931,
+        "name": "Therapeutic Radiographer (Integrated Degree)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 932,
+        "name": "Through life engineering services specialist (integrated degree)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 7"
+    },
+    {
+        "id": 933,
+        "name": "Tool process design engineer",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 934,
+        "name": "Town Planning Assistant",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 935,
+        "name": "Trade Supplier",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 936,
+        "name": "Trade Union Official",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 937,
+        "name": "Train Driver",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 938,
+        "name": "Tramway Construction Operative",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 939,
+        "name": "Transport Planner (Integrated Degree)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 940,
+        "name": "Transport Planning Technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 941,
+        "name": "Travel and Tourism",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 942,
+        "name": "Travel Consultant",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 943,
+        "name": "Tunnelling Operative",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 944,
+        "name": "Turkish",
+        "qualType": "GCSE",
+        "level": "Level 2"
+    },
+    {
+        "id": 945,
+        "name": "Turkish",
+        "qualType": "A Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 946,
+        "name": "Turkish",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 947,
+        "name": "Underkeeper",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 948,
+        "name": "Unified Communications Technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 949,
+        "name": "Urban Driver",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 950,
+        "name": "Urdu",
+        "qualType": "GCSE",
+        "level": "Level 2"
+    },
+    {
+        "id": 951,
+        "name": "Urdu",
+        "qualType": "A Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 952,
+        "name": "Urdu",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 953,
+        "name": "Utilities engineering technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 954,
+        "name": "Vehicle Damage Assessor",
+        "qualType": "End-Point Assessment",
+        "level": "Level 4"
+    },
+    {
+        "id": 955,
+        "name": "Vehicle damage mechanical electrical and trim (MET) technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 956,
+        "name": "Vehicle Damage Paint Technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 957,
+        "name": "Vehicle Damage Panel Technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 958,
+        "name": "Vet technician (livestock)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 5"
+    },
+    {
+        "id": 959,
+        "name": "Veterinary Nurse",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 960,
+        "name": "VFX artist or technical director",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    },
+    {
+        "id": 961,
+        "name": "VFX Supervisor",
+        "qualType": "End-Point Assessment",
+        "level": "Level 7"
+    },
+    {
+        "id": 962,
+        "name": "Wall and Floor Tiler",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 963,
+        "name": "Waste Resource Operative",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 964,
+        "name": "Watchmaker",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 965,
+        "name": "Water Environment Worker",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 966,
+        "name": "Water network operative",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 967,
+        "name": "Water process operative",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 968,
+        "name": "Water process technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 969,
+        "name": "Water treatment technician",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 970,
+        "name": "Wellbeing  and holistic Therapist",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 971,
+        "name": "Welsh second language",
+        "qualType": "A Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 972,
+        "name": "Welsh second language",
+        "qualType": "AS Level",
+        "level": "Level 3"
+    },
+    {
+        "id": 973,
+        "name": "Welsh second language",
+        "qualType": "Other qualification type",
+        "level": "Other qualification level"
+    },
+    {
+        "id": 974,
+        "name": "Wireless Communications Rigger",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 975,
+        "name": "Wood product manufacturing operative",
+        "qualType": "End-Point Assessment",
+        "level": "Level 2"
+    },
+    {
+        "id": 976,
+        "name": "Workboat Crewmember",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 977,
+        "name": "Workplace Pensions (Administrator or Consultant)",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 978,
+        "name": "Youth justice practitioner",
+        "qualType": "End-Point Assessment",
+        "level": "Level 5"
+    },
+    {
+        "id": 979,
+        "name": "Youth support worker",
+        "qualType": "End-Point Assessment",
+        "level": "Level 3"
+    },
+    {
+        "id": 980,
+        "name": "Youth worker",
+        "qualType": "End-Point Assessment",
+        "level": "Level 6"
+    }
+]
 
       var getSuggestions = () => {
         var suggestions = []
@@ -1017,16 +5922,21 @@
         return suggestions;
       }
 
+      function suggest(query, populateResults) {
+        const filteredResults = results.filter(x => x.name.toLowerCase().includes(query.toLowerCase()));
+        populateResults(filteredResults)
+      }
+
       var element = document.querySelector('#tt-default')
       var id = 'autocomplete-default'
       accessibleAutocomplete({
         element: element,
         id: id,
-        source: getSuggestions(),
+        source: suggest,
         name: "subjectSearchResult",
         templates: {
           suggestion: (value) => {
-            var result = results.find(result => result.name == value);
+            var result = results.find(result => result.id == value.id);
             return `<span class='job-title'>${result.name}</span><span class='govuk-hint govuk-!-margin-bottom-0'>${result.qualType}</span><span class='govuk-hint govuk-!-margin-bottom-0'> (${result.level})</span>`
           }
         }

--- a/app/views/application/search/subject-search.html
+++ b/app/views/application/search/subject-search.html
@@ -27,5894 +27,991 @@
 
     <script type="text/javascript">
 
-      var results = [
-    {
-        "id": 0,
-        "name": "Abattoir Worker",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 1,
-        "name": "Academic Professional",
-        "qualType": "End-Point Assessment",
-        "level": "Level 7"
-    },
-    {
-        "id": 2,
-        "name": "Accident repair technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 3,
-        "name": "Accountancy or taxation professional",
-        "qualType": "End-Point Assessment",
-        "level": "Level 7"
-    },
-    {
-        "id": 4,
-        "name": "Accounting",
-        "qualType": "A Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 5,
-        "name": "Accounting",
-        "qualType": "T Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 6,
-        "name": "Accounting",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 7,
-        "name": "Accounts or finance assistant",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 8,
-        "name": "Acoustics Technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 9,
-        "name": "Actuarial Technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 10,
-        "name": "Actuary",
-        "qualType": "End-Point Assessment",
-        "level": "Level 7"
-    },
-    {
-        "id": 11,
-        "name": "Additional mathematics",
-        "qualType": "GCSE",
-        "level": "Level 2"
-    },
-    {
-        "id": 12,
-        "name": "Additional mathematics",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 13,
-        "name": "Adult Care Worker",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 14,
-        "name": "Advanced and Creative Hair Professional",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 15,
-        "name": "Advanced Beauty Therapist",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 16,
-        "name": "Advanced Butcher",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 17,
-        "name": "Advanced Carpentry and Joinery",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 18,
-        "name": "Advanced clinical practitioner (integrated degree)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 7"
-    },
-    {
-        "id": 19,
-        "name": "Advanced credit controller and Debt collection specialist",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 20,
-        "name": "Advanced Dairy Technologist",
-        "qualType": "End-Point Assessment",
-        "level": "Level 5"
-    },
-    {
-        "id": 21,
-        "name": "Advanced Forensic Practitioner (Custody or Sexual Offence)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 7"
-    },
-    {
-        "id": 22,
-        "name": "Advanced Furniture CNC Technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 23,
-        "name": "Advanced Golf Greenkeeper",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 24,
-        "name": "Advanced Upholsterer",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 25,
-        "name": "Advertising and Media Executive",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 26,
-        "name": "Aerospace engineer (degree)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 27,
-        "name": "Aerospace software development engineer (degree)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 28,
-        "name": "Agriculture",
-        "qualType": "GCSE",
-        "level": "Level 2"
-    },
-    {
-        "id": 29,
-        "name": "Agriculture",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 30,
-        "name": "Agriculture or horticulture professional adviser",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 31,
-        "name": "Agriculture, Land Management and Production",
-        "qualType": "T Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 32,
-        "name": "Air Traffic Controller",
-        "qualType": "End-Point Assessment",
-        "level": "Level 5"
-    },
-    {
-        "id": 33,
-        "name": "Aircraft Certifying Technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 34,
-        "name": "Ambulance Support Worker (emergency, urgent, and non-urgent)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 35,
-        "name": "Ancient history",
-        "qualType": "GCSE",
-        "level": "Level 2"
-    },
-    {
-        "id": 36,
-        "name": "Ancient history",
-        "qualType": "A Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 37,
-        "name": "Ancient history",
-        "qualType": "AS Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 38,
-        "name": "Ancient history",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 39,
-        "name": "Animal Care and Management",
-        "qualType": "T Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 40,
-        "name": "Animal Care and Welfare Assistant",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 41,
-        "name": "Animal Technologist",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 42,
-        "name": "Animal Trainer",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 43,
-        "name": "Animation",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 44,
-        "name": "Anti-Social Behaviour and Community Safety Officer",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 45,
-        "name": "Applications support lead",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 46,
-        "name": "Applied Biology",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 47,
-        "name": "Applied Psychology",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 48,
-        "name": "Applied Science",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 49,
-        "name": "Arabic",
-        "qualType": "GCSE",
-        "level": "Level 2"
-    },
-    {
-        "id": 50,
-        "name": "Arabic",
-        "qualType": "A Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 51,
-        "name": "Arabic",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 52,
-        "name": "Arboriculturist",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 53,
-        "name": "Arborist",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 54,
-        "name": "Archaeological specialist (Degree)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 7"
-    },
-    {
-        "id": 55,
-        "name": "Archaeological Technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 56,
-        "name": "Architect (integrated degree)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 7"
-    },
-    {
-        "id": 57,
-        "name": "Architectural assistant (integrated degree)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 58,
-        "name": "Archivist and Records Manager",
-        "qualType": "End-Point Assessment",
-        "level": "Level 7"
-    },
-    {
-        "id": 59,
-        "name": "Art",
-        "qualType": "GCSE",
-        "level": "Level 2"
-    },
-    {
-        "id": 60,
-        "name": "Art",
-        "qualType": "A Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 61,
-        "name": "Art",
-        "qualType": "AS Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 62,
-        "name": "Art",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 63,
-        "name": "Art: 3D studies",
-        "qualType": "GCSE",
-        "level": "Level 2"
-    },
-    {
-        "id": 64,
-        "name": "Art: 3D studies",
-        "qualType": "A Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 65,
-        "name": "Art: 3D studies",
-        "qualType": "AS Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 66,
-        "name": "Art: 3D studies",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 67,
-        "name": "Art: Crafts",
-        "qualType": "GCSE",
-        "level": "Level 2"
-    },
-    {
-        "id": 68,
-        "name": "Art: Crafts",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 69,
-        "name": "Art: Critical studies",
-        "qualType": "GCSE",
-        "level": "Level 2"
-    },
-    {
-        "id": 70,
-        "name": "Art: Critical studies",
-        "qualType": "A Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 71,
-        "name": "Art: Critical studies",
-        "qualType": "AS Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 72,
-        "name": "Art: Critical studies",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 73,
-        "name": "Art: Fine art",
-        "qualType": "GCSE",
-        "level": "Level 2"
-    },
-    {
-        "id": 74,
-        "name": "Art: Fine art",
-        "qualType": "A Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 75,
-        "name": "Art: Fine art",
-        "qualType": "AS Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 76,
-        "name": "Art: Fine art",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 77,
-        "name": "Art: Graphics",
-        "qualType": "GCSE",
-        "level": "Level 2"
-    },
-    {
-        "id": 78,
-        "name": "Art: Graphics",
-        "qualType": "A Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 79,
-        "name": "Art: Graphics",
-        "qualType": "AS Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 80,
-        "name": "Art: Graphics",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 81,
-        "name": "Art: History of art",
-        "qualType": "A Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 82,
-        "name": "Art: History of art",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 83,
-        "name": "Art: Photography",
-        "qualType": "GCSE",
-        "level": "Level 2"
-    },
-    {
-        "id": 84,
-        "name": "Art: Photography",
-        "qualType": "A Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 85,
-        "name": "Art: Photography",
-        "qualType": "AS Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 86,
-        "name": "Art: Photography",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 87,
-        "name": "Art: Textiles",
-        "qualType": "GCSE",
-        "level": "Level 2"
-    },
-    {
-        "id": 88,
-        "name": "Art: Textiles",
-        "qualType": "A Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 89,
-        "name": "Art: Textiles",
-        "qualType": "AS Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 90,
-        "name": "Art: Textiles",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 91,
-        "name": "Artificial Intelligence (AI) Data Specialist",
-        "qualType": "End-Point Assessment",
-        "level": "Level 7"
-    },
-    {
-        "id": 92,
-        "name": "Arts Therapist (Degree)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 7"
-    },
-    {
-        "id": 93,
-        "name": "Asbestos Analyst and Surveyor",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 94,
-        "name": "Assessor Coach",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 95,
-        "name": "Asset manager",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 96,
-        "name": "Assistant Accountant",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 97,
-        "name": "Assistant buyer and assistant merchandiser",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 98,
-        "name": "Assistant Puppet Maker",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 99,
-        "name": "Assistant recording technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 100,
-        "name": "Assistant technical director  (visual effects)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 101,
-        "name": "Associate Ambulance Practitioner",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 102,
-        "name": "Associate Continuing Healthcare Practitioner",
-        "qualType": "End-Point Assessment",
-        "level": "Level 5"
-    },
-    {
-        "id": 103,
-        "name": "Associate Project Manager",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 104,
-        "name": "Astronomy",
-        "qualType": "GCSE",
-        "level": "Level 2"
-    },
-    {
-        "id": 105,
-        "name": "Astronomy",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 106,
-        "name": "Autocare Technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 107,
-        "name": "Automation & Controls Engineering Technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 108,
-        "name": "Automotive Glazing Technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 109,
-        "name": "Aviation Customer Service",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 110,
-        "name": "Aviation Ground Handler",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 111,
-        "name": "Aviation ground operative (above wing)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 112,
-        "name": "Aviation Ground Specialist",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 113,
-        "name": "Aviation Maintenance Mechanic (Military)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 114,
-        "name": "Aviation movement specialist",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 115,
-        "name": "Aviation Operations Manager",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 116,
-        "name": "Baker",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 117,
-        "name": "Beauty and Make Up Consultant",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 118,
-        "name": "Beauty Therapist",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 119,
-        "name": "BEMS (Building energy management systems) controls engineer",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 120,
-        "name": "Bengali",
-        "qualType": "GCSE",
-        "level": "Level 2"
-    },
-    {
-        "id": 121,
-        "name": "Bengali",
-        "qualType": "A Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 122,
-        "name": "Bengali",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 123,
-        "name": "Bespoke Furniture Maker",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 124,
-        "name": "Bespoke Saddler",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 125,
-        "name": "Bespoke Tailor and Cutter",
-        "qualType": "End-Point Assessment",
-        "level": "Level 5"
-    },
-    {
-        "id": 126,
-        "name": "Biblical Hebrew",
-        "qualType": "GCSE",
-        "level": "Level 2"
-    },
-    {
-        "id": 127,
-        "name": "Biblical Hebrew",
-        "qualType": "A Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 128,
-        "name": "Biblical Hebrew",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 129,
-        "name": "Bicycle mechanic",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 130,
-        "name": "Bid and Proposal Co-ordinator",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 131,
-        "name": "Bioinformatics scientist",
-        "qualType": "End-Point Assessment",
-        "level": "Level 7"
-    },
-    {
-        "id": 132,
-        "name": "Biology",
-        "qualType": "GCSE",
-        "level": "Level 2"
-    },
-    {
-        "id": 133,
-        "name": "Biology",
-        "qualType": "A Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 134,
-        "name": "Biology",
-        "qualType": "AS Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 135,
-        "name": "Biology",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 136,
-        "name": "Blacksmith",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 137,
-        "name": "Boatbuilder",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 138,
-        "name": "Boatmaster",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 139,
-        "name": "Bookbinder",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 140,
-        "name": "Brewer",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 141,
-        "name": "Bricklayer",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 142,
-        "name": "Broadcast and Communications Technical Operator",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 143,
-        "name": "Broadcast and media systems engineer (integrated degree)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 144,
-        "name": "Broadcast and Media Systems Technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 5"
-    },
-    {
-        "id": 145,
-        "name": "Broadcast Production Assistant",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 146,
-        "name": "Building Control Surveyor (integrated degree)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 147,
-        "name": "Building services design engineer (degree)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 148,
-        "name": "Building Services Engineering Craftsperson",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 149,
-        "name": "Building Services Engineering Ductwork Craftsperson",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 150,
-        "name": "Building Services Engineering Ductwork installer",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 151,
-        "name": "Building Services Engineering for Construction",
-        "qualType": "T Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 152,
-        "name": "Building Services Engineering Installer",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 153,
-        "name": "Building Services Engineering Service & Maintenance Engineer",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 154,
-        "name": "Building Services Engineering Site Management",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 155,
-        "name": "Building Services Engineering Technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 156,
-        "name": "Building services engineering technician 2022",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 157,
-        "name": "Building services engineering ventilation hygiene technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 158,
-        "name": "Bus and Coach Engineering Technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 159,
-        "name": "Business",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 160,
-        "name": "Business Administrator",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 161,
-        "name": "Business Analyst",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 162,
-        "name": "Business and communication systems",
-        "qualType": "GCSE",
-        "level": "Level 2"
-    },
-    {
-        "id": 163,
-        "name": "Business and communication systems",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 164,
-        "name": "Business Fire Safety Advisor",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 165,
-        "name": "Business studies",
-        "qualType": "GCSE",
-        "level": "Level 2"
-    },
-    {
-        "id": 166,
-        "name": "Business studies",
-        "qualType": "A Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 167,
-        "name": "Business studies",
-        "qualType": "AS Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 168,
-        "name": "Business studies",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 169,
-        "name": "Business to Business Sales Professional (integrated degree)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 170,
-        "name": "Butcher",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 171,
-        "name": "Buying and merchandising assistant",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 172,
-        "name": "Cabin Crew",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 173,
-        "name": "Camera Prep Technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 174,
-        "name": "Career Development Professional",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 175,
-        "name": "Carpentry and Joinery",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 176,
-        "name": "Catering",
-        "qualType": "T Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 177,
-        "name": "Chartered Landscape Professional",
-        "qualType": "End-Point Assessment",
-        "level": "Level 7"
-    },
-    {
-        "id": 178,
-        "name": "Chartered Legal Executive",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 179,
-        "name": "Chartered Manager Degree Apprenticeship",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 180,
-        "name": "Chartered Surveyor",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 181,
-        "name": "Chartered Town Planner (Degree)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 7"
-    },
-    {
-        "id": 182,
-        "name": "Chef de partie",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 183,
-        "name": "Chemistry",
-        "qualType": "GCSE",
-        "level": "Level 2"
-    },
-    {
-        "id": 184,
-        "name": "Chemistry",
-        "qualType": "A Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 185,
-        "name": "Chemistry",
-        "qualType": "AS Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 186,
-        "name": "Chemistry",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 187,
-        "name": "Children, Young People and Families Manager",
-        "qualType": "End-Point Assessment",
-        "level": "Level 5"
-    },
-    {
-        "id": 188,
-        "name": "Children, Young People and Families Practitioner",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 189,
-        "name": "Chinese",
-        "qualType": "GCSE",
-        "level": "Level 2"
-    },
-    {
-        "id": 190,
-        "name": "Chinese",
-        "qualType": "A Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 191,
-        "name": "Chinese",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 192,
-        "name": "Church minister (integrated degree)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 193,
-        "name": "Citizenship studies",
-        "qualType": "GCSE",
-        "level": "Level 2"
-    },
-    {
-        "id": 194,
-        "name": "Citizenship studies",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 195,
-        "name": "Civil Engineer",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 196,
-        "name": "Civil Engineering Site Management",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 197,
-        "name": "Civil engineering technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 198,
-        "name": "Classical civilisation",
-        "qualType": "GCSE",
-        "level": "Level 2"
-    },
-    {
-        "id": 199,
-        "name": "Classical civilisation",
-        "qualType": "A Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 200,
-        "name": "Classical civilisation",
-        "qualType": "AS Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 201,
-        "name": "Classical civilisation",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 202,
-        "name": "Classical Greek",
-        "qualType": "GCSE",
-        "level": "Level 2"
-    },
-    {
-        "id": 203,
-        "name": "Classical Greek",
-        "qualType": "A Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 204,
-        "name": "Classical Greek",
-        "qualType": "AS Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 205,
-        "name": "Classical Greek",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 206,
-        "name": "Classics",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 207,
-        "name": "Clinical associate in psychology (CAP) (integrated degree)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 7"
-    },
-    {
-        "id": 208,
-        "name": "Clinical Coder",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 209,
-        "name": "Clinical dental technician (integrated)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 5"
-    },
-    {
-        "id": 210,
-        "name": "Clinical pharmacology scientist (integrated degree)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 7"
-    },
-    {
-        "id": 211,
-        "name": "Clinical Scientist",
-        "qualType": "End-Point Assessment",
-        "level": "Level 7"
-    },
-    {
-        "id": 212,
-        "name": "Clinical Trials Specialist",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 213,
-        "name": "Clock Maker",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 214,
-        "name": "Coaching Professional",
-        "qualType": "End-Point Assessment",
-        "level": "Level 5"
-    },
-    {
-        "id": 215,
-        "name": "Combined science",
-        "qualType": "GCSE",
-        "level": "Level 2"
-    },
-    {
-        "id": 216,
-        "name": "Combined science",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 217,
-        "name": "Commercial Catering Equipment Technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 218,
-        "name": "Commercial Procurement and Supply (formerly Public sector commercial professional)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 219,
-        "name": "Commercial Thermal Insulation Operative",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 220,
-        "name": "Commis chef",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 221,
-        "name": "Community Activator Coach",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 222,
-        "name": "Community Energy Specialist",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 223,
-        "name": "Community Health and Wellbeing Worker",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 224,
-        "name": "Community Safety Advisor",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 225,
-        "name": "Community Sport and Health Officer",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 226,
-        "name": "Compliance and risk officer",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 227,
-        "name": "Composites Technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 228,
-        "name": "Compressed air and vacuum technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 229,
-        "name": "Computing",
-        "qualType": "GCSE",
-        "level": "Level 2"
-    },
-    {
-        "id": 230,
-        "name": "Computing",
-        "qualType": "A Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 231,
-        "name": "Computing",
-        "qualType": "AS Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 232,
-        "name": "Computing",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 233,
-        "name": "Construction",
-        "qualType": "GCSE",
-        "level": "Level 2"
-    },
-    {
-        "id": 234,
-        "name": "Construction",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 235,
-        "name": "Construction Assembly and Installation Operative",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 236,
-        "name": "Construction Design and Build Technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 237,
-        "name": "Construction Equipment Maintenance Mechanic",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 238,
-        "name": "Construction Plant Operative",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 239,
-        "name": "Construction Quantity Surveying Technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 240,
-        "name": "Construction Quantity Surveyor",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 241,
-        "name": "Construction Site Engineering Technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 242,
-        "name": "Construction Site Management",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 243,
-        "name": "Construction Site Supervisor",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 244,
-        "name": "Construction Support Technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 245,
-        "name": "Control technical support engineer",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 246,
-        "name": "Conveyancing Technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 247,
-        "name": "Corporate responsibility and sustainability practitioner",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 248,
-        "name": "Costume Performance Technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 249,
-        "name": "Counter Fraud Investigator",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 250,
-        "name": "Countryside Ranger",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 251,
-        "name": "Countryside Worker",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 252,
-        "name": "Craft",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 253,
-        "name": "Craft and Design",
-        "qualType": "T Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 254,
-        "name": "Creative Digital",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 255,
-        "name": "Creative digital design professional (integrated degree)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 256,
-        "name": "Creative Digital Media",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 257,
-        "name": "Creative industries production manager  (degree)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 7"
-    },
-    {
-        "id": 258,
-        "name": "Creative Venue Technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 259,
-        "name": "Credit Controller and collector",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 260,
-        "name": "Crop Technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 261,
-        "name": "Cultural Heritage Conservation Technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 262,
-        "name": "Cultural Heritage Conservator",
-        "qualType": "End-Point Assessment",
-        "level": "Level 7"
-    },
-    {
-        "id": 263,
-        "name": "Cultural Learning & Participation Officer",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 264,
-        "name": "Curator",
-        "qualType": "End-Point Assessment",
-        "level": "Level 7"
-    },
-    {
-        "id": 265,
-        "name": "Curtain Wall Installer",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 266,
-        "name": "Custody & Detention Officer",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 267,
-        "name": "Customer Service Practitioner",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 268,
-        "name": "Customer Service Specialist",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 269,
-        "name": "Cyber Security Technical Professional (Integrated Degree)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 270,
-        "name": "Cyber Security Technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 271,
-        "name": "Cyber Security Technologist (2021)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 272,
-        "name": "Dance",
-        "qualType": "GCSE",
-        "level": "Level 2"
-    },
-    {
-        "id": 273,
-        "name": "Dance",
-        "qualType": "A Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 274,
-        "name": "Dance",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 275,
-        "name": "Dance Theatre",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 276,
-        "name": "Data Analyst",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 277,
-        "name": "Data Scientist (Integrated Degree)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 278,
-        "name": "Data Technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 279,
-        "name": "Debt Adviser",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 280,
-        "name": "Demolition Operative",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 281,
-        "name": "Dental Nurse",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 282,
-        "name": "Dental Practice Manager",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 283,
-        "name": "Dental Technician (Integrated)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 5"
-    },
-    {
-        "id": 284,
-        "name": "Design",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 285,
-        "name": "Design and Construction Management (Degree)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 286,
-        "name": "Design and Development for Engineering and Manufacturing",
-        "qualType": "T Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 287,
-        "name": "Design and technology",
-        "qualType": "GCSE",
-        "level": "Level 2"
-    },
-    {
-        "id": 288,
-        "name": "Design and technology",
-        "qualType": "A Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 289,
-        "name": "Design and technology",
-        "qualType": "AS Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 290,
-        "name": "Design and technology",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 291,
-        "name": "Design, Surveying and Planning for Construction",
-        "qualType": "T Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 292,
-        "name": "DevOps Engineer",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 293,
-        "name": "Diagnostic Radiographer (Integrated Degree)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 294,
-        "name": "Dietitian (integrated degree)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 295,
-        "name": "Digital Accessibility Specialist",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 296,
-        "name": "Digital and Technology Solutions Professional (integrated degree)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 297,
-        "name": "Digital and Technology Solutions Specialist (integrated degree)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 7"
-    },
-    {
-        "id": 298,
-        "name": "Digital Business Services",
-        "qualType": "T Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 299,
-        "name": "Digital Community Manager",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 300,
-        "name": "Digital Engineering Technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 301,
-        "name": "Digital Games",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 302,
-        "name": "Digital Marketer",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 303,
-        "name": "Digital marketer integrated degree",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 304,
-        "name": "Digital Media",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 305,
-        "name": "Digital Production, Design and Development",
-        "qualType": "T Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 306,
-        "name": "Digital Support Services",
-        "qualType": "T Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 307,
-        "name": "Digital Support Technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 308,
-        "name": "Digital User Experience (UX) Professional (Integrated Degree)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 309,
-        "name": "District Nurse",
-        "qualType": "End-Point Assessment",
-        "level": "Level 7"
-    },
-    {
-        "id": 310,
-        "name": "Dog groomer",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 311,
-        "name": "Drama",
-        "qualType": "GCSE",
-        "level": "Level 2"
-    },
-    {
-        "id": 312,
-        "name": "Drama",
-        "qualType": "A Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 313,
-        "name": "Drama",
-        "qualType": "AS Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 314,
-        "name": "Drama",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 315,
-        "name": "Drinks dispense technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 316,
-        "name": "Dual Fuel Smart Meter Installer",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 317,
-        "name": "Early intervention practitioner",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 318,
-        "name": "Early years educator",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 319,
-        "name": "Early Years Practitioner",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 320,
-        "name": "Ecologist",
-        "qualType": "End-Point Assessment",
-        "level": "Level 7"
-    },
-    {
-        "id": 321,
-        "name": "Economics",
-        "qualType": "GCSE",
-        "level": "Level 2"
-    },
-    {
-        "id": 322,
-        "name": "Economics",
-        "qualType": "A Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 323,
-        "name": "Economics",
-        "qualType": "AS Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 324,
-        "name": "Economics",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 325,
-        "name": "Education and Childcare",
-        "qualType": "T Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 326,
-        "name": "Education Technician (HE Assistant Technician & Simulation-based Technician)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 327,
-        "name": "Electrical Electronic Product Servicing and Installation Engineer",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 328,
-        "name": "Electrical or electronic technical support engineer (degree)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 329,
-        "name": "Electrical power networks engineer",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 330,
-        "name": "Electrical power protection and plant commissioning engineer",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 331,
-        "name": "Electro-mechanical engineer",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 332,
-        "name": "Electronic Systems Principal Engineer",
-        "qualType": "End-Point Assessment",
-        "level": "Level 7"
-    },
-    {
-        "id": 333,
-        "name": "Electronics",
-        "qualType": "GCSE",
-        "level": "Level 2"
-    },
-    {
-        "id": 334,
-        "name": "Electronics",
-        "qualType": "A Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 335,
-        "name": "Electronics",
-        "qualType": "AS Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 336,
-        "name": "Electronics",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 337,
-        "name": "Embedded electronic systems design and development engineer (degree)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 338,
-        "name": "Emergency Service Contact Handler",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 339,
-        "name": "Employability Practitioner",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 340,
-        "name": "Engineer Surveyor",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 341,
-        "name": "Engineering",
-        "qualType": "GCSE",
-        "level": "Level 2"
-    },
-    {
-        "id": 342,
-        "name": "Engineering",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 343,
-        "name": "Engineering construction erector rigger",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 344,
-        "name": "Engineering Construction Pipefitter",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 345,
-        "name": "Engineering design and draughtsperson",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 346,
-        "name": "Engineering fitter",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 347,
-        "name": "Engineering Manufacturing Technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 348,
-        "name": "Engineering Operative",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 349,
-        "name": "Engineering Technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 350,
-        "name": "Engineering, Manufacturing, Processing and Control",
-        "qualType": "T Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 351,
-        "name": "English language",
-        "qualType": "GCSE",
-        "level": "Level 2"
-    },
-    {
-        "id": 352,
-        "name": "English language",
-        "qualType": "A Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 353,
-        "name": "English language",
-        "qualType": "AS Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 354,
-        "name": "English language",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 355,
-        "name": "English language and literature",
-        "qualType": "A Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 356,
-        "name": "English language and literature",
-        "qualType": "AS Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 357,
-        "name": "English literature",
-        "qualType": "GCSE",
-        "level": "Level 2"
-    },
-    {
-        "id": 358,
-        "name": "English literature",
-        "qualType": "A Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 359,
-        "name": "English literature",
-        "qualType": "AS Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 360,
-        "name": "English literature",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 361,
-        "name": "Enhanced Clinical Practitioner",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 362,
-        "name": "Environmental health practitioner (integrated degree)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 363,
-        "name": "Environmental practitioner",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 364,
-        "name": "Environmental Science",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 365,
-        "name": "Environmental studies",
-        "qualType": "A Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 366,
-        "name": "Environmental studies",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 367,
-        "name": "Environmental technology",
-        "qualType": "A Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 368,
-        "name": "Environmental technology",
-        "qualType": "AS Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 369,
-        "name": "Environmental technology",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 370,
-        "name": "Equine groom",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 371,
-        "name": "Event Assistant",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 372,
-        "name": "Express delivery Manager",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 373,
-        "name": "Express delivery operative",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 374,
-        "name": "Express delivery sortation hub operative",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 375,
-        "name": "Facilities Management Supervisor",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 376,
-        "name": "Facilities Manager",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 377,
-        "name": "Facilities Services Operative",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 378,
-        "name": "Fall Protection Technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 379,
-        "name": "Farrier",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 380,
-        "name": "Fashion and Textiles Pattern Cutter",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 381,
-        "name": "Fashion and textiles product technologist",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 382,
-        "name": "Fashion Studio Assistant",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 383,
-        "name": "Fencing Installer",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 384,
-        "name": "Fenestration fabricator",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 385,
-        "name": "Fenestration Installer",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 386,
-        "name": "Film",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 387,
-        "name": "Film Studies",
-        "qualType": "GCSE",
-        "level": "Level 2"
-    },
-    {
-        "id": 388,
-        "name": "Film studies",
-        "qualType": "A Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 389,
-        "name": "Film studies",
-        "qualType": "AS Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 390,
-        "name": "Film studies",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 391,
-        "name": "Finance",
-        "qualType": "T Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 392,
-        "name": "Financial Advisor",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 393,
-        "name": "Financial Services Administrator",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 394,
-        "name": "Financial Services Customer Adviser",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 395,
-        "name": "Financial Services Professional",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 396,
-        "name": "Fire Emergency and Security Systems Technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 397,
-        "name": "Fire Safety Engineer (Degree)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 398,
-        "name": "Fire Safety Inspector",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 399,
-        "name": "First Officer Pilot",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 400,
-        "name": "Fisher",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 401,
-        "name": "Fishmonger",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 402,
-        "name": "Fitted Furniture Design Technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 403,
-        "name": "Floorlayer",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 404,
-        "name": "Florist",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 405,
-        "name": "Food",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 406,
-        "name": "Food and drink advanced engineer (integrated degree)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 407,
-        "name": "Food and Drink Engineer",
-        "qualType": "End-Point Assessment",
-        "level": "Level 5"
-    },
-    {
-        "id": 408,
-        "name": "Food and Drink Maintenance Engineer",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 409,
-        "name": "Food and drink process operator",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 410,
-        "name": "Food and drink technical operator",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 411,
-        "name": "Food industry technical professional (integrated degree)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 412,
-        "name": "Food preparation and nutrition",
-        "qualType": "GCSE",
-        "level": "Level 2"
-    },
-    {
-        "id": 413,
-        "name": "Food preparation and nutrition",
-        "qualType": "GCSE",
-        "level": "Level 2"
-    },
-    {
-        "id": 414,
-        "name": "Food preparation and nutrition",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 415,
-        "name": "Food Technologist",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 416,
-        "name": "Footwear manufacturer",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 417,
-        "name": "Forensic Collision Investigator",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 418,
-        "name": "Forest Operative",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 419,
-        "name": "Formworker",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 420,
-        "name": "French",
-        "qualType": "GCSE",
-        "level": "Level 2"
-    },
-    {
-        "id": 421,
-        "name": "French",
-        "qualType": "A Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 422,
-        "name": "French",
-        "qualType": "AS Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 423,
-        "name": "French",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 424,
-        "name": "Fundraiser",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 425,
-        "name": "Funeral Director",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 426,
-        "name": "Funeral Team Member",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 427,
-        "name": "Furniture Manufacturer",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 428,
-        "name": "Further mathematics",
-        "qualType": "GCSE",
-        "level": "Level 2"
-    },
-    {
-        "id": 429,
-        "name": "Further mathematics",
-        "qualType": "A Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 430,
-        "name": "Further mathematics",
-        "qualType": "AS Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 431,
-        "name": "Further mathematics",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 432,
-        "name": "Game programmer",
-        "qualType": "End-Point Assessment",
-        "level": "Level 7"
-    },
-    {
-        "id": 433,
-        "name": "Garment Maker",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 434,
-        "name": "Gas Engineering Operative",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 435,
-        "name": "Gas Network Craftsperson",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 436,
-        "name": "Gas Network Operative",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 437,
-        "name": "General farm worker",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 438,
-        "name": "General Welder (Arc Processes)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 439,
-        "name": "Geography",
-        "qualType": "GCSE",
-        "level": "Level 2"
-    },
-    {
-        "id": 440,
-        "name": "Geography",
-        "qualType": "A Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 441,
-        "name": "Geography",
-        "qualType": "AS Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 442,
-        "name": "Geography",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 443,
-        "name": "Geology",
-        "qualType": "GCSE",
-        "level": "Level 2"
-    },
-    {
-        "id": 444,
-        "name": "Geology",
-        "qualType": "A Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 445,
-        "name": "Geology",
-        "qualType": "AS Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 446,
-        "name": "Geology",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 447,
-        "name": "Geospatial Mapping and Science Specialist (Degree)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 448,
-        "name": "Geospatial Survey Technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 449,
-        "name": "Geotechnical engineer (integrated degree)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 7"
-    },
-    {
-        "id": 450,
-        "name": "German",
-        "qualType": "GCSE",
-        "level": "Level 2"
-    },
-    {
-        "id": 451,
-        "name": "German",
-        "qualType": "A Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 452,
-        "name": "German",
-        "qualType": "AS Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 453,
-        "name": "German",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 454,
-        "name": "Golf Course Manager",
-        "qualType": "End-Point Assessment",
-        "level": "Level 5"
-    },
-    {
-        "id": 455,
-        "name": "Golf Greenkeeper",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 456,
-        "name": "Greek",
-        "qualType": "GCSE",
-        "level": "Level 2"
-    },
-    {
-        "id": 457,
-        "name": "Greek",
-        "qualType": "A Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 458,
-        "name": "Greek",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 459,
-        "name": "Groundworker",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 460,
-        "name": "Gujarati",
-        "qualType": "GCSE",
-        "level": "Level 2"
-    },
-    {
-        "id": 461,
-        "name": "Gujarati",
-        "qualType": "A Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 462,
-        "name": "Gujarati",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 463,
-        "name": "Hair Professional",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 464,
-        "name": "Hairdressing, Barbering and Beauty Therapy",
-        "qualType": "T Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 465,
-        "name": "Harbour Master",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 466,
-        "name": "Health",
-        "qualType": "T Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 467,
-        "name": "Health and Care Intelligence Specialist",
-        "qualType": "End-Point Assessment",
-        "level": "Level 7"
-    },
-    {
-        "id": 468,
-        "name": "Health and social care",
-        "qualType": "A Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 469,
-        "name": "Health and social care",
-        "qualType": "AS Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 470,
-        "name": "Health and social care",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 471,
-        "name": "Health Play Specialist",
-        "qualType": "End-Point Assessment",
-        "level": "Level 5"
-    },
-    {
-        "id": 472,
-        "name": "Healthcare assistant practitioner",
-        "qualType": "End-Point Assessment",
-        "level": "Level 5"
-    },
-    {
-        "id": 473,
-        "name": "Healthcare Cleaning Operative",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 474,
-        "name": "Healthcare engineering specialist technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 475,
-        "name": "Healthcare Science",
-        "qualType": "T Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 476,
-        "name": "Healthcare science assistant",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 477,
-        "name": "Healthcare science associate",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 478,
-        "name": "Healthcare Science Practitioner (Integrated Degree)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 479,
-        "name": "healthcare support worker",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 480,
-        "name": "Hearing Aid Dispenser",
-        "qualType": "End-Point Assessment",
-        "level": "Level 5"
-    },
-    {
-        "id": 481,
-        "name": "Heavy vehicle service and maintenance technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 482,
-        "name": "Heritage Engineering Technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 483,
-        "name": "High Speed Rail and Infrastructure Technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 484,
-        "name": "Highway Electrical Maintenance and Installation Operative",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 485,
-        "name": "Highways Electrician or Service Operative",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 486,
-        "name": "Highways Maintenance Skilled Operative",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 487,
-        "name": "Hire Controller (Plant, Tools and Equipment)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 488,
-        "name": "Historic Environment Advice Assistant",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 489,
-        "name": "Historic Environment Advisor",
-        "qualType": "End-Point Assessment",
-        "level": "Level 7"
-    },
-    {
-        "id": 490,
-        "name": "History",
-        "qualType": "GCSE",
-        "level": "Level 2"
-    },
-    {
-        "id": 491,
-        "name": "History",
-        "qualType": "A Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 492,
-        "name": "History",
-        "qualType": "AS Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 493,
-        "name": "History",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 494,
-        "name": "HM Forces Serviceperson (public services)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 495,
-        "name": "Home economics",
-        "qualType": "GCSE",
-        "level": "Level 2"
-    },
-    {
-        "id": 496,
-        "name": "Home economics",
-        "qualType": "A Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 497,
-        "name": "Home economics",
-        "qualType": "AS Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 498,
-        "name": "Home economics",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 499,
-        "name": "Horticulture and landscaping technical manager",
-        "qualType": "End-Point Assessment",
-        "level": "Level 5"
-    },
-    {
-        "id": 500,
-        "name": "Horticulture Operative or Landscape",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 501,
-        "name": "Hospitality",
-        "qualType": "GCSE",
-        "level": "Level 2"
-    },
-    {
-        "id": 502,
-        "name": "Hospitality",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 503,
-        "name": "Hospitality Manager",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 504,
-        "name": "Hospitality Supervisor",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 505,
-        "name": "Hospitality Team Member",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 506,
-        "name": "Housing and Property Management",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 507,
-        "name": "Housing and Property Management Assistant",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 508,
-        "name": "HR consultant partner",
-        "qualType": "End-Point Assessment",
-        "level": "Level 5"
-    },
-    {
-        "id": 509,
-        "name": "HR Support",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 510,
-        "name": "Hygiene Specialist",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 511,
-        "name": "ICT",
-        "qualType": "GCSE",
-        "level": "Level 2"
-    },
-    {
-        "id": 512,
-        "name": "ICT",
-        "qualType": "A Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 513,
-        "name": "ICT",
-        "qualType": "AS Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 514,
-        "name": "ICT",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 515,
-        "name": "Improvement leader",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 516,
-        "name": "Improvement practitioner",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 517,
-        "name": "Improvement specialist",
-        "qualType": "End-Point Assessment",
-        "level": "Level 5"
-    },
-    {
-        "id": 518,
-        "name": "Improvement technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 519,
-        "name": "Industrial Coatings Applicator",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 520,
-        "name": "Industrial Thermal Insulation Technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 521,
-        "name": "Information Communications Technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 522,
-        "name": "Information Manager",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 523,
-        "name": "Installation Electrician and Maintenance Electrician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 524,
-        "name": "Insurance practitioner",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 525,
-        "name": "Insurance Professional",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 526,
-        "name": "Intelligence Analyst",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 527,
-        "name": "Interior Systems Installer",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 528,
-        "name": "Internal Audit Practitioner",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 529,
-        "name": "Internal Audit Professional",
-        "qualType": "End-Point Assessment",
-        "level": "Level 7"
-    },
-    {
-        "id": 530,
-        "name": "International Freight Forwarding Specialist",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 531,
-        "name": "Investment Operations Administrator",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 532,
-        "name": "Investment Operations Specialist",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 533,
-        "name": "Investment Operations Technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 534,
-        "name": "Irish",
-        "qualType": "GCSE",
-        "level": "Level 2"
-    },
-    {
-        "id": 535,
-        "name": "Irish",
-        "qualType": "A Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 536,
-        "name": "Irish",
-        "qualType": "AS Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 537,
-        "name": "Irish",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 538,
-        "name": "IT solutions technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 539,
-        "name": "IT Technical Salesperson",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 540,
-        "name": "Italian",
-        "qualType": "GCSE",
-        "level": "Level 2"
-    },
-    {
-        "id": 541,
-        "name": "Italian",
-        "qualType": "A Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 542,
-        "name": "Italian",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 543,
-        "name": "Japanese",
-        "qualType": "GCSE",
-        "level": "Level 2"
-    },
-    {
-        "id": 544,
-        "name": "Japanese",
-        "qualType": "A Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 545,
-        "name": "Japanese",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 546,
-        "name": "Jewellery, silversmithing, and allied trades professional",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 547,
-        "name": "Journalism",
-        "qualType": "GCSE",
-        "level": "Level 2"
-    },
-    {
-        "id": 548,
-        "name": "Journalism",
-        "qualType": "A Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 549,
-        "name": "Journalism",
-        "qualType": "AS Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 550,
-        "name": "Journalism",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 551,
-        "name": "Journalist",
-        "qualType": "End-Point Assessment",
-        "level": "Level 5"
-    },
-    {
-        "id": 552,
-        "name": "Junior 2D Artist  (visual effects)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 553,
-        "name": "Junior advertising creative",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 554,
-        "name": "Junior Animator",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 555,
-        "name": "Junior Content Producer",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 556,
-        "name": "Junior Energy Manager",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 557,
-        "name": "Junior Estate Agent",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 558,
-        "name": "Junior Management Consultant",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 559,
-        "name": "Junior VFX Artist (Generalist)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 560,
-        "name": "Keeper and aquarist",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 561,
-        "name": "Knitted product manufacturing technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 562,
-        "name": "Laboratory Scientist (degree)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 563,
-        "name": "Laboratory Technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 564,
-        "name": "Land Based Service Engineer",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 565,
-        "name": "Land Referencer",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 566,
-        "name": "Land-based service engineering technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 567,
-        "name": "Landscape or Horticulture Supervisor",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 568,
-        "name": "Landscape Technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 569,
-        "name": "Large Goods Vehicle( LGV) Driver C+E",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 570,
-        "name": "Latin",
-        "qualType": "GCSE",
-        "level": "Level 2"
-    },
-    {
-        "id": 571,
-        "name": "Latin",
-        "qualType": "A Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 572,
-        "name": "Latin",
-        "qualType": "AS Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 573,
-        "name": "Latin",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 574,
-        "name": "Law",
-        "qualType": "A Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 575,
-        "name": "Law",
-        "qualType": "AS Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 576,
-        "name": "Law",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 577,
-        "name": "Lead adult care worker",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 578,
-        "name": "Lead Practitioner in Adult Care",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 579,
-        "name": "Leader in Adult Care",
-        "qualType": "End-Point Assessment",
-        "level": "Level 5"
-    },
-    {
-        "id": 580,
-        "name": "Lean manufacturing operative",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 581,
-        "name": "Learning and development consultant business partner",
-        "qualType": "End-Point Assessment",
-        "level": "Level 5"
-    },
-    {
-        "id": 582,
-        "name": "Learning and development practitioner",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 583,
-        "name": "Learning and Skills Teacher",
-        "qualType": "End-Point Assessment",
-        "level": "Level 5"
-    },
-    {
-        "id": 584,
-        "name": "Learning Mentor",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 585,
-        "name": "Leather Craftsperson",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 586,
-        "name": "Legal Services",
-        "qualType": "T Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 587,
-        "name": "Leisure and tourism",
-        "qualType": "GCSE",
-        "level": "Level 2"
-    },
-    {
-        "id": 588,
-        "name": "Leisure and tourism",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 589,
-        "name": "Leisure duty manager",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 590,
-        "name": "Leisure Team Member",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 591,
-        "name": "Level 5 Early Years Lead Practitioner",
-        "qualType": "End-Point Assessment",
-        "level": "Level 5"
-    },
-    {
-        "id": 592,
-        "name": "Library, information & archive services assistant",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 593,
-        "name": "Licensed Conveyancer",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 594,
-        "name": "Life and health science",
-        "qualType": "A Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 595,
-        "name": "Life and health science",
-        "qualType": "AS Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 596,
-        "name": "Life and health science",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 597,
-        "name": "Lift and escalator electromechanic",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 598,
-        "name": "Lift Truck and Powered Access Engineering Technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 599,
-        "name": "Lifting Equipment Technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 600,
-        "name": "Lifting Technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 601,
-        "name": "Lightning Protection Operative",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 602,
-        "name": "Literature",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 603,
-        "name": "Live Event Rigger",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 604,
-        "name": "Live Event Technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 605,
-        "name": "Livestock unit technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 606,
-        "name": "Maintenance and operations engineering technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 607,
-        "name": "Maintenance, Installation and Repair for Engineering and Manufacturing",
-        "qualType": "T Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 608,
-        "name": "Mammography Associate",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 609,
-        "name": "Management and Administration",
-        "qualType": "T Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 610,
-        "name": "Manufacturing engineer (degree)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 611,
-        "name": "Manufacturing Manager (integrated degree)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 612,
-        "name": "Marina and Boatyard Operative",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 613,
-        "name": "Marine electrician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 614,
-        "name": "Marine engineer",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 615,
-        "name": "Marine Pilot",
-        "qualType": "End-Point Assessment",
-        "level": "Level 5"
-    },
-    {
-        "id": 616,
-        "name": "Marine Surveyor (degree)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 617,
-        "name": "Marine technical superintendent (degree)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 7"
-    },
-    {
-        "id": 618,
-        "name": "Maritime Caterer",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 619,
-        "name": "Maritime mechanical and electrical mechanic",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 620,
-        "name": "Market research executive",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 621,
-        "name": "Marketing Assistant",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 622,
-        "name": "Marketing Executive",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 623,
-        "name": "Marketing Manager",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 624,
-        "name": "Mastic Asphalter",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 625,
-        "name": "Material cutter",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 626,
-        "name": "Materials process engineer (degree)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 7"
-    },
-    {
-        "id": 627,
-        "name": "Materials Science Technologist (Degree)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 628,
-        "name": "Mathematics",
-        "qualType": "GCSE",
-        "level": "Level 2"
-    },
-    {
-        "id": 629,
-        "name": "Mathematics",
-        "qualType": "A Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 630,
-        "name": "Mathematics",
-        "qualType": "AS Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 631,
-        "name": "Mathematics",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 632,
-        "name": "Media",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 633,
-        "name": "Media Production Co-ordinator",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 634,
-        "name": "Media studies",
-        "qualType": "GCSE",
-        "level": "Level 2"
-    },
-    {
-        "id": 635,
-        "name": "Media studies",
-        "qualType": "A Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 636,
-        "name": "Media studies",
-        "qualType": "AS Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 637,
-        "name": "Media studies",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 638,
-        "name": "Media, Broadcast and Production",
-        "qualType": "T Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 639,
-        "name": "Medical Statistician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 7"
-    },
-    {
-        "id": 640,
-        "name": "Metal casting, foundry and patternmaking technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 641,
-        "name": "Metal Fabricator",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 642,
-        "name": "Metal Recycling General Operative",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 643,
-        "name": "Metal Recycling Technical Manager (MRTM)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 5"
-    },
-    {
-        "id": 644,
-        "name": "Metrology Technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 645,
-        "name": "Midwife",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 646,
-        "name": "Midwife (2019 NMC standards) (degree)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 647,
-        "name": "Military Engineering Construction Technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 648,
-        "name": "Mineral and Construction Product Sampling and Testing Operations",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 649,
-        "name": "Mineral processing mobile and static plant operator",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 650,
-        "name": "Mineral Processing Weighbridge Operator",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 651,
-        "name": "Mineral Products Technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 5"
-    },
-    {
-        "id": 652,
-        "name": "Modern Hebrew",
-        "qualType": "GCSE",
-        "level": "Level 2"
-    },
-    {
-        "id": 653,
-        "name": "Modern Hebrew",
-        "qualType": "A Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 654,
-        "name": "Modern Hebrew",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 655,
-        "name": "Mortgage Adviser",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 656,
-        "name": "Motor Finance Specialist",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 657,
-        "name": "Motor Vehicle Service and Maintenance Technician (Light Vehicle)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 658,
-        "name": "Motor vehicle studies",
-        "qualType": "GCSE",
-        "level": "Level 2"
-    },
-    {
-        "id": 659,
-        "name": "Motor vehicle studies",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 660,
-        "name": "Motorcycle technician (repair and maintenance)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 661,
-        "name": "Moving image arts",
-        "qualType": "GCSE",
-        "level": "Level 2"
-    },
-    {
-        "id": 662,
-        "name": "Moving image arts",
-        "qualType": "A Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 663,
-        "name": "Moving image arts",
-        "qualType": "AS Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 664,
-        "name": "Moving image arts",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 665,
-        "name": "Museums and Galleries Technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 666,
-        "name": "Music",
-        "qualType": "GCSE",
-        "level": "Level 2"
-    },
-    {
-        "id": 667,
-        "name": "Music",
-        "qualType": "A Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 668,
-        "name": "Music",
-        "qualType": "AS Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 669,
-        "name": "Music",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 670,
-        "name": "Music technology",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 671,
-        "name": "Nail Services Technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 672,
-        "name": "Network Cable Installer",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 673,
-        "name": "Network Engineer",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 674,
-        "name": "Network Operations",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 675,
-        "name": "New Furniture Product Developer",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 676,
-        "name": "Non-destructive testing (NDT) operator",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 677,
-        "name": "Non-destructive testing engineer (degree)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 678,
-        "name": "Non-destructive testing engineering technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 679,
-        "name": "Non-Home Office Police Officer",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 680,
-        "name": "Nuclear Health Physics Monitor",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 681,
-        "name": "Nuclear operative",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 682,
-        "name": "Nuclear reactor desk engineer",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 683,
-        "name": "Nuclear scientist and nuclear engineer (integrated degree)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 684,
-        "name": "Nuclear Technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 5"
-    },
-    {
-        "id": 685,
-        "name": "Nuclear welding inspection technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 686,
-        "name": "NULL",
-        "qualType": "A Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 687,
-        "name": "NULL",
-        "qualType": "AS Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 688,
-        "name": "NULL",
-        "qualType": "AS Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 689,
-        "name": "Nursing associate (NMC 2018)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 5"
-    },
-    {
-        "id": 690,
-        "name": "Occupational Therapist (Integrated Degree)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 691,
-        "name": "Officer of the watch (near coastal)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 692,
-        "name": "Onsite Construction",
-        "qualType": "T Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 693,
-        "name": "Operating Department Practitioner (Integrated Degree)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 694,
-        "name": "Operational firefighter",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 695,
-        "name": "Operational Research Specialist",
-        "qualType": "End-Point Assessment",
-        "level": "Level 7"
-    },
-    {
-        "id": 696,
-        "name": "Operations or departmental manager",
-        "qualType": "End-Point Assessment",
-        "level": "Level 5"
-    },
-    {
-        "id": 697,
-        "name": "Optical Assistant",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 698,
-        "name": "Oral Health Practitioner",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 699,
-        "name": "Ordnance munitions and explosives (OME) professional (integrated degree)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 700,
-        "name": "Ordnance Munitions and Explosives Specialist  (integrated degree)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 7"
-    },
-    {
-        "id": 701,
-        "name": "Ordnance Munitions Explosives Technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 702,
-        "name": "Organ builder",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 703,
-        "name": "Orthodontic therapist (integrated)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 704,
-        "name": "Outdoor Activity Instructor",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 705,
-        "name": "Outside broadcasting engineer (integrated degree)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 7"
-    },
-    {
-        "id": 706,
-        "name": "Packaging professional (integrated degree)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 707,
-        "name": "Packhouse Line Leader",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 708,
-        "name": "Painter and Decorator",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 709,
-        "name": "Panjabi",
-        "qualType": "GCSE",
-        "level": "Level 2"
-    },
-    {
-        "id": 710,
-        "name": "Panjabi",
-        "qualType": "A Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 711,
-        "name": "Panjabi",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 712,
-        "name": "Papermaker",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 713,
-        "name": "Paralegal",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 714,
-        "name": "Paramedic (integrated degree)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 715,
-        "name": "Paraplanner",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 716,
-        "name": "Passenger transport driver - bus, coach and tram",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 717,
-        "name": "Passenger Transport Operations Manager",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 718,
-        "name": "Passenger transport operative",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 719,
-        "name": "Payroll Administrator",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 720,
-        "name": "Payroll Assistant Manager",
-        "qualType": "End-Point Assessment",
-        "level": "Level 5"
-    },
-    {
-        "id": 721,
-        "name": "Performing arts",
-        "qualType": "A Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 722,
-        "name": "Performing arts",
-        "qualType": "AS Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 723,
-        "name": "Performing arts",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 724,
-        "name": "Persian",
-        "qualType": "GCSE",
-        "level": "Level 2"
-    },
-    {
-        "id": 725,
-        "name": "Persian",
-        "qualType": "A Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 726,
-        "name": "Persian",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 727,
-        "name": "Personal  Trainer",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 728,
-        "name": "Pest Control Technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 729,
-        "name": "Pharmacy services assistant",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 730,
-        "name": "Pharmacy Technician (Integrated)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 731,
-        "name": "Philosophy",
-        "qualType": "A Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 732,
-        "name": "Philosophy",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 733,
-        "name": "Photographic Assistant",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 734,
-        "name": "Photography",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 735,
-        "name": "Physical education",
-        "qualType": "GCSE",
-        "level": "Level 2"
-    },
-    {
-        "id": 736,
-        "name": "Physical education",
-        "qualType": "A Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 737,
-        "name": "Physical education",
-        "qualType": "AS Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 738,
-        "name": "Physical education",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 739,
-        "name": "Physician Associate",
-        "qualType": "End-Point Assessment",
-        "level": "Level 7"
-    },
-    {
-        "id": 740,
-        "name": "Physics",
-        "qualType": "GCSE",
-        "level": "Level 2"
-    },
-    {
-        "id": 741,
-        "name": "Physics",
-        "qualType": "A Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 742,
-        "name": "Physics",
-        "qualType": "AS Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 743,
-        "name": "Physics",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 744,
-        "name": "Physiotherapist (Integrated Degree)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 745,
-        "name": "Piling Attendant",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 746,
-        "name": "Pipe Welder",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 747,
-        "name": "Plasterer",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 748,
-        "name": "Plate Welder",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 749,
-        "name": "Play therapist",
-        "qualType": "End-Point Assessment",
-        "level": "Level 7"
-    },
-    {
-        "id": 750,
-        "name": "Plumbing and Domestic Heating Technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 751,
-        "name": "Podiatrist (integrated degree)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 752,
-        "name": "Police Community Support Officer",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 753,
-        "name": "Police Constable (integrated degree)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 754,
-        "name": "Policy Officer",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 755,
-        "name": "Polish",
-        "qualType": "GCSE",
-        "level": "Level 2"
-    },
-    {
-        "id": 756,
-        "name": "Polish",
-        "qualType": "A Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 757,
-        "name": "Polish",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 758,
-        "name": "Political studies",
-        "qualType": "GCSE",
-        "level": "Level 2"
-    },
-    {
-        "id": 759,
-        "name": "Political studies",
-        "qualType": "A Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 760,
-        "name": "Political studies",
-        "qualType": "AS Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 761,
-        "name": "Political studies",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 762,
-        "name": "Port Marine Operations Officer",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 763,
-        "name": "Port operative",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 764,
-        "name": "Portuguese",
-        "qualType": "GCSE",
-        "level": "Level 2"
-    },
-    {
-        "id": 765,
-        "name": "Portuguese",
-        "qualType": "A Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 766,
-        "name": "Portuguese",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 767,
-        "name": "Post graduate engineer",
-        "qualType": "End-Point Assessment",
-        "level": "Level 7"
-    },
-    {
-        "id": 768,
-        "name": "Post Production Engineer",
-        "qualType": "End-Point Assessment",
-        "level": "Level 5"
-    },
-    {
-        "id": 769,
-        "name": "Post- Production Technical Operator",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 770,
-        "name": "Poultry Technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 771,
-        "name": "Poultry Worker",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 772,
-        "name": "Power and Propulsion Gas Turbine Engineer",
-        "qualType": "End-Point Assessment",
-        "level": "Level 7"
-    },
-    {
-        "id": 773,
-        "name": "Power Network Craftsperson",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 774,
-        "name": "Powered Pedestrian Door Installer and Service Engineer",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 775,
-        "name": "Preparation for life and work",
-        "qualType": "GCSE",
-        "level": "Level 2"
-    },
-    {
-        "id": 776,
-        "name": "Preparation for life and work",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 777,
-        "name": "Print operative",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 778,
-        "name": "Print Technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 779,
-        "name": "Probate Technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 780,
-        "name": "Process automation engineer (degree)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 7"
-    },
-    {
-        "id": 781,
-        "name": "Process leader",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 782,
-        "name": "Procurement and supply assistant",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 783,
-        "name": "Product design and development engineer (degree)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 784,
-        "name": "Production arts",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 785,
-        "name": "Production Chef",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 786,
-        "name": "Professional Accounting or Taxation Technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 787,
-        "name": "Professional Arboriculturist",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 788,
-        "name": "Professional economist (integrated degree)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 789,
-        "name": "Professional Forester",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 790,
-        "name": "Project",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 791,
-        "name": "Project controls professional",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 792,
-        "name": "Project Controls Technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 793,
-        "name": "Project Manager (integrated degree)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 794,
-        "name": "Property Maintenance Operative",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 795,
-        "name": "Props Technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 796,
-        "name": "Propulsion Technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 797,
-        "name": "Prosthetic and Orthotic technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 798,
-        "name": "Prosthetist and Orthotist (Integrated Degree)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 799,
-        "name": "Psychological Wellbeing Practitioner (PWP)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 800,
-        "name": "Psychology",
-        "qualType": "GCSE",
-        "level": "Level 2"
-    },
-    {
-        "id": 801,
-        "name": "Psychology",
-        "qualType": "A Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 802,
-        "name": "Psychology",
-        "qualType": "AS Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 803,
-        "name": "Psychology",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 804,
-        "name": "Public health practitioner (integrated degree)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 805,
-        "name": "Public relations and communications assistant",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 806,
-        "name": "Public sector compliance Investigator and officer",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 807,
-        "name": "Public Service Operational Delivery Officer",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 808,
-        "name": "Publishing Assistant",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 809,
-        "name": "Quality Practitioner",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 810,
-        "name": "Radio Network Technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 811,
-        "name": "Rail  engineering  advanced technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 812,
-        "name": "Rail & Rail Systems Senior Engineer (integrated degree)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 813,
-        "name": "Rail and Rail Systems Engineer",
-        "qualType": "End-Point Assessment",
-        "level": "Level 5"
-    },
-    {
-        "id": 814,
-        "name": "Rail and rail systems principal engineer (integrated degree)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 7"
-    },
-    {
-        "id": 815,
-        "name": "Rail Engineering Operative",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 816,
-        "name": "Rail Engineering Technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 817,
-        "name": "Rail Infrastructure Operator",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 818,
-        "name": "Railway Engineering Design Technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 819,
-        "name": "Recruitment Consultant",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 820,
-        "name": "Recruitment Resourcer",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 821,
-        "name": "Refrigeration air conditioning and heat pump engineering technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 822,
-        "name": "Registered Nurse  - Degree (NMC 2010)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 823,
-        "name": "Registered Nurse Degree (NMC 2018)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 824,
-        "name": "Registrar (Creative and Cultural)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 825,
-        "name": "Regulatory Affairs Specialist",
-        "qualType": "End-Point Assessment",
-        "level": "Level 7"
-    },
-    {
-        "id": 826,
-        "name": "Regulatory Compliance Officer",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 827,
-        "name": "Rehabilitation Worker (Visual Impairment)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 5"
-    },
-    {
-        "id": 828,
-        "name": "Religious",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 829,
-        "name": "Religious studies",
-        "qualType": "GCSE",
-        "level": "Level 2"
-    },
-    {
-        "id": 830,
-        "name": "Religious studies",
-        "qualType": "A Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 831,
-        "name": "Religious studies",
-        "qualType": "AS Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 832,
-        "name": "Religious studies",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 833,
-        "name": "Research scientist",
-        "qualType": "End-Point Assessment",
-        "level": "Level 7"
-    },
-    {
-        "id": 834,
-        "name": "Retail leadership degree apprenticeship",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 835,
-        "name": "Retail Manager",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 836,
-        "name": "Retail Team Leader",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 837,
-        "name": "Retailer",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 838,
-        "name": "Revenues and Welfare Benefits Practitioner",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 839,
-        "name": "Risk and safety management professional (degree)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 7"
-    },
-    {
-        "id": 840,
-        "name": "Road surfacing operative",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 841,
-        "name": "Road Transport engineering manager",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 842,
-        "name": "Roofer",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 843,
-        "name": "Russian",
-        "qualType": "GCSE",
-        "level": "Level 2"
-    },
-    {
-        "id": 844,
-        "name": "Russian",
-        "qualType": "A Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 845,
-        "name": "Russian",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 846,
-        "name": "Safety, health and environment technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 847,
-        "name": "Sales Executive",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 848,
-        "name": "Scaffolder",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 849,
-        "name": "School Business Professional",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 850,
-        "name": "Science",
-        "qualType": "GCSE",
-        "level": "Level 2"
-    },
-    {
-        "id": 851,
-        "name": "Science",
-        "qualType": "T Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 852,
-        "name": "Science",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 853,
-        "name": "Science Industry Maintenance Technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 854,
-        "name": "Science industry process and plant engineer (degree)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 855,
-        "name": "Science manufacturing process operative",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 856,
-        "name": "Science Manufacturing Technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 857,
-        "name": "Seafarer (Deck Rating)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 858,
-        "name": "Security First Line Manager",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 859,
-        "name": "Senior and head of facilities management (integrated degree)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 860,
-        "name": "Senior compliance and risk specialist",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 861,
-        "name": "Senior Culinary Chef",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 862,
-        "name": "Senior Equine Groom",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 863,
-        "name": "Senior financial services customer adviser",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 864,
-        "name": "Senior Healthcare Support Worker",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 865,
-        "name": "Senior housing and property management",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 866,
-        "name": "Senior Insurance Professional",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 867,
-        "name": "Senior investment and commercial banking professional",
-        "qualType": "End-Point Assessment",
-        "level": "Level 7"
-    },
-    {
-        "id": 868,
-        "name": "Senior Journalist",
-        "qualType": "End-Point Assessment",
-        "level": "Level 7"
-    },
-    {
-        "id": 869,
-        "name": "Senior Leader",
-        "qualType": "End-Point Assessment",
-        "level": "Level 7"
-    },
-    {
-        "id": 870,
-        "name": "Senior Metrology Technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 5"
-    },
-    {
-        "id": 871,
-        "name": "Senior People Professional",
-        "qualType": "End-Point Assessment",
-        "level": "Level 7"
-    },
-    {
-        "id": 872,
-        "name": "Senior Production Chef",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 873,
-        "name": "Senior professional economist (integrated degree)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 7"
-    },
-    {
-        "id": 874,
-        "name": "Serious and complex crime investigator (integrated degree)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 875,
-        "name": "Sewing machinist",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 876,
-        "name": "Signage technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 877,
-        "name": "Smart Home Technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 878,
-        "name": "Social worker (integrated degree)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 879,
-        "name": "Sociology",
-        "qualType": "GCSE",
-        "level": "Level 2"
-    },
-    {
-        "id": 880,
-        "name": "Sociology",
-        "qualType": "A Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 881,
-        "name": "Sociology",
-        "qualType": "AS Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 882,
-        "name": "Sociology",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 883,
-        "name": "Software Developer",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 884,
-        "name": "Software Development Technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 885,
-        "name": "Software Tester",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 886,
-        "name": "Solicitor",
-        "qualType": "End-Point Assessment",
-        "level": "Level 7"
-    },
-    {
-        "id": 887,
-        "name": "Sonographer (Integrated degree)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 888,
-        "name": "Space Engineering Technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 889,
-        "name": "Spanish",
-        "qualType": "GCSE",
-        "level": "Level 2"
-    },
-    {
-        "id": 890,
-        "name": "Spanish",
-        "qualType": "A Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 891,
-        "name": "Spanish",
-        "qualType": "AS Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 892,
-        "name": "Spanish",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 893,
-        "name": "Specialist community and public health nurse",
-        "qualType": "End-Point Assessment",
-        "level": "Level 7"
-    },
-    {
-        "id": 894,
-        "name": "Specialist Rescue Operative",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 895,
-        "name": "Specialist Tyre Operative",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 896,
-        "name": "Spectacle maker",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 897,
-        "name": "Speech and Language Therapist (Integrated Degree)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 898,
-        "name": "Sport",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 899,
-        "name": "Sporting Excellence Professional",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 900,
-        "name": "Sports coach",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 901,
-        "name": "Sports Turf Operative",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 902,
-        "name": "Stained glass craftsperson",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 903,
-        "name": "Stairlift, Platform Lift, Service Lift Electromechanic",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 904,
-        "name": "Statistics",
-        "qualType": "GCSE",
-        "level": "Level 2"
-    },
-    {
-        "id": 905,
-        "name": "Statistics",
-        "qualType": "A Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 906,
-        "name": "Statistics",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 907,
-        "name": "Steel fixer",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 908,
-        "name": "Stonemason",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 909,
-        "name": "Storyboard Artist",
-        "qualType": "End-Point Assessment",
-        "level": "Level 7"
-    },
-    {
-        "id": 910,
-        "name": "Structural Steelwork Erector",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 911,
-        "name": "Structural Steelwork Fabricator",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 912,
-        "name": "Supply chain leadership professional (integrated degree)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 913,
-        "name": "Supply Chain Operator",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 914,
-        "name": "Supply Chain Practitioner (Fast Moving Consumer Good)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 915,
-        "name": "Supply Chain Warehouse Operative",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 916,
-        "name": "Surveying Technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 917,
-        "name": "Survival equipment fitter",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 918,
-        "name": "Sustainability business specialist  (integrated degree)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 7"
-    },
-    {
-        "id": 919,
-        "name": "Systems Engineer",
-        "qualType": "End-Point Assessment",
-        "level": "Level 7"
-    },
-    {
-        "id": 920,
-        "name": "Systems Thinking Practitioner",
-        "qualType": "End-Point Assessment",
-        "level": "Level 7"
-    },
-    {
-        "id": 921,
-        "name": "Teacher",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 922,
-        "name": "Teaching Assistant",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 923,
-        "name": "Team Leader or supervisor",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 924,
-        "name": "Technical dyer and colourist",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 925,
-        "name": "Technician Scientist",
-        "qualType": "End-Point Assessment",
-        "level": "Level 5"
-    },
-    {
-        "id": 926,
-        "name": "Telecoms Field Operative",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 927,
-        "name": "Textile care operative",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 928,
-        "name": "Textile Manufacturing Operative",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 929,
-        "name": "Textile Technical Specialist",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 930,
-        "name": "Theatre",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 931,
-        "name": "Therapeutic Radiographer (Integrated Degree)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 932,
-        "name": "Through life engineering services specialist (integrated degree)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 7"
-    },
-    {
-        "id": 933,
-        "name": "Tool process design engineer",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 934,
-        "name": "Town Planning Assistant",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 935,
-        "name": "Trade Supplier",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 936,
-        "name": "Trade Union Official",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 937,
-        "name": "Train Driver",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 938,
-        "name": "Tramway Construction Operative",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 939,
-        "name": "Transport Planner (Integrated Degree)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 940,
-        "name": "Transport Planning Technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 941,
-        "name": "Travel and Tourism",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 942,
-        "name": "Travel Consultant",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 943,
-        "name": "Tunnelling Operative",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 944,
-        "name": "Turkish",
-        "qualType": "GCSE",
-        "level": "Level 2"
-    },
-    {
-        "id": 945,
-        "name": "Turkish",
-        "qualType": "A Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 946,
-        "name": "Turkish",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 947,
-        "name": "Underkeeper",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 948,
-        "name": "Unified Communications Technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 949,
-        "name": "Urban Driver",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 950,
-        "name": "Urdu",
-        "qualType": "GCSE",
-        "level": "Level 2"
-    },
-    {
-        "id": 951,
-        "name": "Urdu",
-        "qualType": "A Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 952,
-        "name": "Urdu",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 953,
-        "name": "Utilities engineering technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 954,
-        "name": "Vehicle Damage Assessor",
-        "qualType": "End-Point Assessment",
-        "level": "Level 4"
-    },
-    {
-        "id": 955,
-        "name": "Vehicle damage mechanical electrical and trim (MET) technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 956,
-        "name": "Vehicle Damage Paint Technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 957,
-        "name": "Vehicle Damage Panel Technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 958,
-        "name": "Vet technician (livestock)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 5"
-    },
-    {
-        "id": 959,
-        "name": "Veterinary Nurse",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 960,
-        "name": "VFX artist or technical director",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    },
-    {
-        "id": 961,
-        "name": "VFX Supervisor",
-        "qualType": "End-Point Assessment",
-        "level": "Level 7"
-    },
-    {
-        "id": 962,
-        "name": "Wall and Floor Tiler",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 963,
-        "name": "Waste Resource Operative",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 964,
-        "name": "Watchmaker",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 965,
-        "name": "Water Environment Worker",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 966,
-        "name": "Water network operative",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 967,
-        "name": "Water process operative",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 968,
-        "name": "Water process technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 969,
-        "name": "Water treatment technician",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 970,
-        "name": "Wellbeing  and holistic Therapist",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 971,
-        "name": "Welsh second language",
-        "qualType": "A Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 972,
-        "name": "Welsh second language",
-        "qualType": "AS Level",
-        "level": "Level 3"
-    },
-    {
-        "id": 973,
-        "name": "Welsh second language",
-        "qualType": "Other qualification type",
-        "level": "Other qualification level"
-    },
-    {
-        "id": 974,
-        "name": "Wireless Communications Rigger",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 975,
-        "name": "Wood product manufacturing operative",
-        "qualType": "End-Point Assessment",
-        "level": "Level 2"
-    },
-    {
-        "id": 976,
-        "name": "Workboat Crewmember",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 977,
-        "name": "Workplace Pensions (Administrator or Consultant)",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 978,
-        "name": "Youth justice practitioner",
-        "qualType": "End-Point Assessment",
-        "level": "Level 5"
-    },
-    {
-        "id": 979,
-        "name": "Youth support worker",
-        "qualType": "End-Point Assessment",
-        "level": "Level 3"
-    },
-    {
-        "id": 980,
-        "name": "Youth worker",
-        "qualType": "End-Point Assessment",
-        "level": "Level 6"
-    }
-]
+      var rawResults = [
+        { "name": "Abattoir Worker", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Academic Professional", "qualType": "End-Point Assessment", "level": "Level 7" },
+        { "name": "Accident repair technician", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Accountancy or taxation professional", "qualType": "End-Point Assessment", "level": "Level 7" },
+        { "name": "Accounting", "qualType": "A Level", "level": "Level 3" },
+        { "name": "Accounting", "qualType": "T Level", "level": "Level 3" },
+        { "name": "Accounting", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Accounts or finance assistant", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Acoustics Technician", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Actuarial Technician", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Actuary", "qualType": "End-Point Assessment", "level": "Level 7" },
+        { "name": "Additional mathematics", "qualType": "GCSE", "level": "Level 2" },
+        { "name": "Additional mathematics", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Adult Care Worker", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Advanced and Creative Hair Professional", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Advanced Beauty Therapist", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Advanced Butcher", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Advanced Carpentry and Joinery", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Advanced clinical practitioner (integrated degree)", "qualType": "End-Point Assessment", "level": "Level 7" },
+        { "name": "Advanced credit controller and Debt collection specialist", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Advanced Dairy Technologist", "qualType": "End-Point Assessment", "level": "Level 5" },
+        { "name": "Advanced Forensic Practitioner (Custody or Sexual Offence)", "qualType": "End-Point Assessment", "level": "Level 7" },
+        { "name": "Advanced Furniture CNC Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Advanced Golf Greenkeeper", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Advanced Upholsterer", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Advertising and Media Executive", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Aerospace engineer (degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Aerospace software development engineer (degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Agriculture", "qualType": "GCSE", "level": "Level 2" },
+        { "name": "Agriculture", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Agriculture or horticulture professional adviser", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Agriculture, Land Management and Production", "qualType": "T Level", "level": "Level 3" },
+        { "name": "Air Traffic Controller", "qualType": "End-Point Assessment", "level": "Level 5" },
+        { "name": "Aircraft Certifying Technician", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Ambulance Support Worker (emergency, urgent, and non-urgent)", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Ancient history", "qualType": "GCSE", "level": "Level 2" },
+        { "name": "Ancient history", "qualType": "A Level", "level": "Level 3" },
+        { "name": "Ancient history", "qualType": "AS Level", "level": "Level 3" },
+        { "name": "Ancient history", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Animal Care and Management", "qualType": "T Level", "level": "Level 3" },
+        { "name": "Animal Care and Welfare Assistant", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Animal Technologist", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Animal Trainer", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Animation", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Anti-Social Behaviour and Community Safety Officer", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Applications support lead", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Applied Biology", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Applied Psychology", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Applied Science", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Arabic", "qualType": "GCSE", "level": "Level 2" },
+        { "name": "Arabic", "qualType": "A Level", "level": "Level 3" },
+        { "name": "Arabic", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Arboriculturist", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Arborist", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Archaeological specialist (Degree)", "qualType": "End-Point Assessment", "level": "Level 7" },
+        { "name": "Archaeological Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Architect (integrated degree)", "qualType": "End-Point Assessment", "level": "Level 7" },
+        { "name": "Architectural assistant (integrated degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Archivist and Records Manager", "qualType": "End-Point Assessment", "level": "Level 7" },
+        { "name": "Art", "qualType": "GCSE", "level": "Level 2" },
+        { "name": "Art", "qualType": "A Level", "level": "Level 3" },
+        { "name": "Art", "qualType": "AS Level", "level": "Level 3" },
+        { "name": "Art", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Art: 3D studies", "qualType": "GCSE", "level": "Level 2" },
+        { "name": "Art: 3D studies", "qualType": "A Level", "level": "Level 3" },
+        { "name": "Art: 3D studies", "qualType": "AS Level", "level": "Level 3" },
+        { "name": "Art: 3D studies", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Art: Crafts", "qualType": "GCSE", "level": "Level 2" },
+        { "name": "Art: Crafts", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Art: Critical studies", "qualType": "GCSE", "level": "Level 2" },
+        { "name": "Art: Critical studies", "qualType": "A Level", "level": "Level 3" },
+        { "name": "Art: Critical studies", "qualType": "AS Level", "level": "Level 3" },
+        { "name": "Art: Critical studies", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Art: Fine art", "qualType": "GCSE", "level": "Level 2" },
+        { "name": "Art: Fine art", "qualType": "A Level", "level": "Level 3" },
+        { "name": "Art: Fine art", "qualType": "AS Level", "level": "Level 3" },
+        { "name": "Art: Fine art", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Art: Graphics", "qualType": "GCSE", "level": "Level 2" },
+        { "name": "Art: Graphics", "qualType": "A Level", "level": "Level 3" },
+        { "name": "Art: Graphics", "qualType": "AS Level", "level": "Level 3" },
+        { "name": "Art: Graphics", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Art: History of art", "qualType": "A Level", "level": "Level 3" },
+        { "name": "Art: History of art", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Art: Photography", "qualType": "GCSE", "level": "Level 2" },
+        { "name": "Art: Photography", "qualType": "A Level", "level": "Level 3" },
+        { "name": "Art: Photography", "qualType": "AS Level", "level": "Level 3" },
+        { "name": "Art: Photography", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Art: Textiles", "qualType": "GCSE", "level": "Level 2" },
+        { "name": "Art: Textiles", "qualType": "A Level", "level": "Level 3" },
+        { "name": "Art: Textiles", "qualType": "AS Level", "level": "Level 3" },
+        { "name": "Art: Textiles", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Artificial Intelligence (AI) Data Specialist", "qualType": "End-Point Assessment", "level": "Level 7" },
+        { "name": "Arts Therapist (Degree)", "qualType": "End-Point Assessment", "level": "Level 7" },
+        { "name": "Asbestos Analyst and Surveyor", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Assessor Coach", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Asset manager", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Assistant Accountant", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Assistant buyer and assistant merchandiser", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Assistant Puppet Maker", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Assistant recording technician", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Assistant technical director  (visual effects)", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Associate Ambulance Practitioner", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Associate Continuing Healthcare Practitioner", "qualType": "End-Point Assessment", "level": "Level 5" },
+        { "name": "Associate Project Manager", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Astronomy", "qualType": "GCSE", "level": "Level 2" },
+        { "name": "Astronomy", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Autocare Technician", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Automation & Controls Engineering Technician", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Automotive Glazing Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Aviation Customer Service", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Aviation Ground Handler", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Aviation ground operative (above wing)", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Aviation Ground Specialist", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Aviation Maintenance Mechanic (Military)", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Aviation movement specialist", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Aviation Operations Manager", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Baker", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Beauty and Make Up Consultant", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Beauty Therapist", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "BEMS (Building energy management systems) controls engineer", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Bengali", "qualType": "GCSE", "level": "Level 2" },
+        { "name": "Bengali", "qualType": "A Level", "level": "Level 3" },
+        { "name": "Bengali", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Bespoke Furniture Maker", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Bespoke Saddler", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Bespoke Tailor and Cutter", "qualType": "End-Point Assessment", "level": "Level 5" },
+        { "name": "Biblical Hebrew", "qualType": "GCSE", "level": "Level 2" },
+        { "name": "Biblical Hebrew", "qualType": "A Level", "level": "Level 3" },
+        { "name": "Biblical Hebrew", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Bicycle mechanic", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Bid and Proposal Co-ordinator", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Bioinformatics scientist", "qualType": "End-Point Assessment", "level": "Level 7" },
+        { "name": "Biology", "qualType": "GCSE", "level": "Level 2" },
+        { "name": "Biology", "qualType": "A Level", "level": "Level 3" },
+        { "name": "Biology", "qualType": "AS Level", "level": "Level 3" },
+        { "name": "Biology", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Blacksmith", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Boatbuilder", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Boatmaster", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Bookbinder", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Brewer", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Bricklayer", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Broadcast and Communications Technical Operator", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Broadcast and media systems engineer (integrated degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Broadcast and Media Systems Technician", "qualType": "End-Point Assessment", "level": "Level 5" },
+        { "name": "Broadcast Production Assistant", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Building Control Surveyor (integrated degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Building services design engineer (degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Building Services Engineering Craftsperson", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Building Services Engineering Ductwork Craftsperson", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Building Services Engineering Ductwork installer", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Building Services Engineering for Construction", "qualType": "T Level", "level": "Level 3" },
+        { "name": "Building Services Engineering Installer", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Building Services Engineering Service & Maintenance Engineer", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Building Services Engineering Site Management", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Building Services Engineering Technician", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Building services engineering technician 2022", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Building services engineering ventilation hygiene technician", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Bus and Coach Engineering Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Business", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Business Administrator", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Business Analyst", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Business and communication systems", "qualType": "GCSE", "level": "Level 2" },
+        { "name": "Business and communication systems", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Business Fire Safety Advisor", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Business studies", "qualType": "GCSE", "level": "Level 2" },
+        { "name": "Business studies", "qualType": "A Level", "level": "Level 3" },
+        { "name": "Business studies", "qualType": "AS Level", "level": "Level 3" },
+        { "name": "Business studies", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Business to Business Sales Professional (integrated degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Butcher", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Buying and merchandising assistant", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Cabin Crew", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Camera Prep Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Career Development Professional", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Carpentry and Joinery", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Catering", "qualType": "T Level", "level": "Level 3" },
+        { "name": "Chartered Landscape Professional", "qualType": "End-Point Assessment", "level": "Level 7" },
+        { "name": "Chartered Legal Executive", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Chartered Manager Degree Apprenticeship", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Chartered Surveyor", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Chartered Town Planner (Degree)", "qualType": "End-Point Assessment", "level": "Level 7" },
+        { "name": "Chef de partie", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Chemistry", "qualType": "GCSE", "level": "Level 2" },
+        { "name": "Chemistry", "qualType": "A Level", "level": "Level 3" },
+        { "name": "Chemistry", "qualType": "AS Level", "level": "Level 3" },
+        { "name": "Chemistry", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Children, Young People and Families Manager", "qualType": "End-Point Assessment", "level": "Level 5" },
+        { "name": "Children, Young People and Families Practitioner", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Chinese", "qualType": "GCSE", "level": "Level 2" },
+        { "name": "Chinese", "qualType": "A Level", "level": "Level 3" },
+        { "name": "Chinese", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Church minister (integrated degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Citizenship studies", "qualType": "GCSE", "level": "Level 2" },
+        { "name": "Citizenship studies", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Civil Engineer", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Civil Engineering Site Management", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Civil engineering technician", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Classical civilisation", "qualType": "GCSE", "level": "Level 2" },
+        { "name": "Classical civilisation", "qualType": "A Level", "level": "Level 3" },
+        { "name": "Classical civilisation", "qualType": "AS Level", "level": "Level 3" },
+        { "name": "Classical civilisation", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Classical Greek", "qualType": "GCSE", "level": "Level 2" },
+        { "name": "Classical Greek", "qualType": "A Level", "level": "Level 3" },
+        { "name": "Classical Greek", "qualType": "AS Level", "level": "Level 3" },
+        { "name": "Classical Greek", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Classics", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Clinical associate in psychology (CAP) (integrated degree)", "qualType": "End-Point Assessment", "level": "Level 7" },
+        { "name": "Clinical Coder", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Clinical dental technician (integrated)", "qualType": "End-Point Assessment", "level": "Level 5" },
+        { "name": "Clinical pharmacology scientist (integrated degree)", "qualType": "End-Point Assessment", "level": "Level 7" },
+        { "name": "Clinical Scientist", "qualType": "End-Point Assessment", "level": "Level 7" },
+        { "name": "Clinical Trials Specialist", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Clock Maker", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Coaching Professional", "qualType": "End-Point Assessment", "level": "Level 5" },
+        { "name": "Combined science", "qualType": "GCSE", "level": "Level 2" },
+        { "name": "Combined science", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Commercial Catering Equipment Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Commercial Procurement and Supply (formerly Public sector commercial professional)", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Commercial Thermal Insulation Operative", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Commis chef", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Community Activator Coach", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Community Energy Specialist", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Community Health and Wellbeing Worker", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Community Safety Advisor", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Community Sport and Health Officer", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Compliance and risk officer", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Composites Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Compressed air and vacuum technician", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Computing", "qualType": "GCSE", "level": "Level 2" },
+        { "name": "Computing", "qualType": "A Level", "level": "Level 3" },
+        { "name": "Computing", "qualType": "AS Level", "level": "Level 3" },
+        { "name": "Computing", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Construction", "qualType": "GCSE", "level": "Level 2" },
+        { "name": "Construction", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Construction Assembly and Installation Operative", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Construction Design and Build Technician", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Construction Equipment Maintenance Mechanic", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Construction Plant Operative", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Construction Quantity Surveying Technician", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Construction Quantity Surveyor", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Construction Site Engineering Technician", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Construction Site Management", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Construction Site Supervisor", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Construction Support Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Control technical support engineer", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Conveyancing Technician", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Corporate responsibility and sustainability practitioner", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Costume Performance Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Counter Fraud Investigator", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Countryside Ranger", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Countryside Worker", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Craft", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Craft and Design", "qualType": "T Level", "level": "Level 3" },
+        { "name": "Creative Digital", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Creative digital design professional (integrated degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Creative Digital Media", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Creative industries production manager  (degree)", "qualType": "End-Point Assessment", "level": "Level 7" },
+        { "name": "Creative Venue Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Credit Controller and collector", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Crop Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Cultural Heritage Conservation Technician", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Cultural Heritage Conservator", "qualType": "End-Point Assessment", "level": "Level 7" },
+        { "name": "Cultural Learning & Participation Officer", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Curator", "qualType": "End-Point Assessment", "level": "Level 7" },
+        { "name": "Curtain Wall Installer", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Custody & Detention Officer", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Customer Service Practitioner", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Customer Service Specialist", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Cyber Security Technical Professional (Integrated Degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Cyber Security Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Cyber Security Technologist (2021)", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Dance", "qualType": "GCSE", "level": "Level 2" },
+        { "name": "Dance", "qualType": "A Level", "level": "Level 3" },
+        { "name": "Dance", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Dance Theatre", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Data Analyst", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Data Scientist (Integrated Degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Data Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Debt Adviser", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Demolition Operative", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Dental Nurse", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Dental Practice Manager", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Dental Technician (Integrated)", "qualType": "End-Point Assessment", "level": "Level 5" },
+        { "name": "Design", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Design and Construction Management (Degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Design and Development for Engineering and Manufacturing", "qualType": "T Level", "level": "Level 3" },
+        { "name": "Design and technology", "qualType": "GCSE", "level": "Level 2" },
+        { "name": "Design and technology", "qualType": "A Level", "level": "Level 3" },
+        { "name": "Design and technology", "qualType": "AS Level", "level": "Level 3" },
+        { "name": "Design and technology", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Design, Surveying and Planning for Construction", "qualType": "T Level", "level": "Level 3" },
+        { "name": "DevOps Engineer", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Diagnostic Radiographer (Integrated Degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Dietitian (integrated degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Digital Accessibility Specialist", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Digital and Technology Solutions Professional (integrated degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Digital and Technology Solutions Specialist (integrated degree)", "qualType": "End-Point Assessment", "level": "Level 7" },
+        { "name": "Digital Business Services", "qualType": "T Level", "level": "Level 3" },
+        { "name": "Digital Community Manager", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Digital Engineering Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Digital Games", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Digital Marketer", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Digital marketer integrated degree", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Digital Media", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Digital Production, Design and Development", "qualType": "T Level", "level": "Level 3" },
+        { "name": "Digital Support Services", "qualType": "T Level", "level": "Level 3" },
+        { "name": "Digital Support Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Digital User Experience (UX) Professional (Integrated Degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "District Nurse", "qualType": "End-Point Assessment", "level": "Level 7" },
+        { "name": "Dog groomer", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Drama", "qualType": "GCSE", "level": "Level 2" },
+        { "name": "Drama", "qualType": "A Level", "level": "Level 3" },
+        { "name": "Drama", "qualType": "AS Level", "level": "Level 3" },
+        { "name": "Drama", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Drinks dispense technician", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Dual Fuel Smart Meter Installer", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Early intervention practitioner", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Early years educator", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Early Years Practitioner", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Ecologist", "qualType": "End-Point Assessment", "level": "Level 7" },
+        { "name": "Economics", "qualType": "GCSE", "level": "Level 2" },
+        { "name": "Economics", "qualType": "A Level", "level": "Level 3" },
+        { "name": "Economics", "qualType": "AS Level", "level": "Level 3" },
+        { "name": "Economics", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Education and Childcare", "qualType": "T Level", "level": "Level 3" },
+        { "name": "Education Technician (HE Assistant Technician & Simulation-based Technician)", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Electrical Electronic Product Servicing and Installation Engineer", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Electrical or electronic technical support engineer (degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Electrical power networks engineer", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Electrical power protection and plant commissioning engineer", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Electro-mechanical engineer", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Electronic Systems Principal Engineer", "qualType": "End-Point Assessment", "level": "Level 7" },
+        { "name": "Electronics", "qualType": "GCSE", "level": "Level 2" },
+        { "name": "Electronics", "qualType": "A Level", "level": "Level 3" },
+        { "name": "Electronics", "qualType": "AS Level", "level": "Level 3" },
+        { "name": "Electronics", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Embedded electronic systems design and development engineer (degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Emergency Service Contact Handler", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Employability Practitioner", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Engineer Surveyor", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Engineering", "qualType": "GCSE", "level": "Level 2" },
+        { "name": "Engineering", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Engineering construction erector rigger", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Engineering Construction Pipefitter", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Engineering design and draughtsperson", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Engineering fitter", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Engineering Manufacturing Technician", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Engineering Operative", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Engineering Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Engineering, Manufacturing, Processing and Control", "qualType": "T Level", "level": "Level 3" },
+        { "name": "English language", "qualType": "GCSE", "level": "Level 2" },
+        { "name": "English language", "qualType": "A Level", "level": "Level 3" },
+        { "name": "English language", "qualType": "AS Level", "level": "Level 3" },
+        { "name": "English language", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "English language and literature", "qualType": "A Level", "level": "Level 3" },
+        { "name": "English language and literature", "qualType": "AS Level", "level": "Level 3" },
+        { "name": "English literature", "qualType": "GCSE", "level": "Level 2" },
+        { "name": "English literature", "qualType": "A Level", "level": "Level 3" },
+        { "name": "English literature", "qualType": "AS Level", "level": "Level 3" },
+        { "name": "English literature", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Enhanced Clinical Practitioner", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Environmental health practitioner (integrated degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Environmental practitioner", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Environmental Science", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Environmental studies", "qualType": "A Level", "level": "Level 3" },
+        { "name": "Environmental studies", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Environmental technology", "qualType": "A Level", "level": "Level 3" },
+        { "name": "Environmental technology", "qualType": "AS Level", "level": "Level 3" },
+        { "name": "Environmental technology", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Equine groom", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Event Assistant", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Express delivery Manager", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Express delivery operative", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Express delivery sortation hub operative", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Facilities Management Supervisor", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Facilities Manager", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Facilities Services Operative", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Fall Protection Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Farrier", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Fashion and Textiles Pattern Cutter", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Fashion and textiles product technologist", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Fashion Studio Assistant", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Fencing Installer", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Fenestration fabricator", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Fenestration Installer", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Film", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Film Studies", "qualType": "GCSE", "level": "Level 2" },
+        { "name": "Film studies", "qualType": "A Level", "level": "Level 3" },
+        { "name": "Film studies", "qualType": "AS Level", "level": "Level 3" },
+        { "name": "Film studies", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Finance", "qualType": "T Level", "level": "Level 3" },
+        { "name": "Financial Advisor", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Financial Services Administrator", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Financial Services Customer Adviser", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Financial Services Professional", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Fire Emergency and Security Systems Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Fire Safety Engineer (Degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Fire Safety Inspector", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "First Officer Pilot", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Fisher", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Fishmonger", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Fitted Furniture Design Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Floorlayer", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Florist", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Food", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Food and drink advanced engineer (integrated degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Food and Drink Engineer", "qualType": "End-Point Assessment", "level": "Level 5" },
+        { "name": "Food and Drink Maintenance Engineer", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Food and drink process operator", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Food and drink technical operator", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Food industry technical professional (integrated degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Food preparation and nutrition", "qualType": "GCSE", "level": "Level 2" },
+        { "name": "Food preparation and nutrition", "qualType": "GCSE", "level": "Level 2" },
+        { "name": "Food preparation and nutrition", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Food Technologist", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Footwear manufacturer", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Forensic Collision Investigator", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Forest Operative", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Formworker", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "French", "qualType": "GCSE", "level": "Level 2" },
+        { "name": "French", "qualType": "A Level", "level": "Level 3" },
+        { "name": "French", "qualType": "AS Level", "level": "Level 3" },
+        { "name": "French", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Fundraiser", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Funeral Director", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Funeral Team Member", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Furniture Manufacturer", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Further mathematics", "qualType": "GCSE", "level": "Level 2" },
+        { "name": "Further mathematics", "qualType": "A Level", "level": "Level 3" },
+        { "name": "Further mathematics", "qualType": "AS Level", "level": "Level 3" },
+        { "name": "Further mathematics", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Game programmer", "qualType": "End-Point Assessment", "level": "Level 7" },
+        { "name": "Garment Maker", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Gas Engineering Operative", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Gas Network Craftsperson", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Gas Network Operative", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "General farm worker", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "General Welder (Arc Processes)", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Geography", "qualType": "GCSE", "level": "Level 2" },
+        { "name": "Geography", "qualType": "A Level", "level": "Level 3" },
+        { "name": "Geography", "qualType": "AS Level", "level": "Level 3" },
+        { "name": "Geography", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Geology", "qualType": "GCSE", "level": "Level 2" },
+        { "name": "Geology", "qualType": "A Level", "level": "Level 3" },
+        { "name": "Geology", "qualType": "AS Level", "level": "Level 3" },
+        { "name": "Geology", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Geospatial Mapping and Science Specialist (Degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Geospatial Survey Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Geotechnical engineer (integrated degree)", "qualType": "End-Point Assessment", "level": "Level 7" },
+        { "name": "German", "qualType": "GCSE", "level": "Level 2" },
+        { "name": "German", "qualType": "A Level", "level": "Level 3" },
+        { "name": "German", "qualType": "AS Level", "level": "Level 3" },
+        { "name": "German", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Golf Course Manager", "qualType": "End-Point Assessment", "level": "Level 5" },
+        { "name": "Golf Greenkeeper", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Greek", "qualType": "GCSE", "level": "Level 2" },
+        { "name": "Greek", "qualType": "A Level", "level": "Level 3" },
+        { "name": "Greek", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Groundworker", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Gujarati", "qualType": "GCSE", "level": "Level 2" },
+        { "name": "Gujarati", "qualType": "A Level", "level": "Level 3" },
+        { "name": "Gujarati", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Hair Professional", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Hairdressing, Barbering and Beauty Therapy", "qualType": "T Level", "level": "Level 3" },
+        { "name": "Harbour Master", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Health", "qualType": "T Level", "level": "Level 3" },
+        { "name": "Health and Care Intelligence Specialist", "qualType": "End-Point Assessment", "level": "Level 7" },
+        { "name": "Health and social care", "qualType": "A Level", "level": "Level 3" },
+        { "name": "Health and social care", "qualType": "AS Level", "level": "Level 3" },
+        { "name": "Health and social care", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Health Play Specialist", "qualType": "End-Point Assessment", "level": "Level 5" },
+        { "name": "Healthcare assistant practitioner", "qualType": "End-Point Assessment", "level": "Level 5" },
+        { "name": "Healthcare Cleaning Operative", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Healthcare engineering specialist technician", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Healthcare Science", "qualType": "T Level", "level": "Level 3" },
+        { "name": "Healthcare science assistant", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Healthcare science associate", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Healthcare Science Practitioner (Integrated Degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "healthcare support worker", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Hearing Aid Dispenser", "qualType": "End-Point Assessment", "level": "Level 5" },
+        { "name": "Heavy vehicle service and maintenance technician", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Heritage Engineering Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "High Speed Rail and Infrastructure Technician", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Highway Electrical Maintenance and Installation Operative", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Highways Electrician or Service Operative", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Highways Maintenance Skilled Operative", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Hire Controller (Plant, Tools and Equipment)", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Historic Environment Advice Assistant", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Historic Environment Advisor", "qualType": "End-Point Assessment", "level": "Level 7" },
+        { "name": "History", "qualType": "GCSE", "level": "Level 2" },
+        { "name": "History", "qualType": "A Level", "level": "Level 3" },
+        { "name": "History", "qualType": "AS Level", "level": "Level 3" },
+        { "name": "History", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "HM Forces Serviceperson (public services)", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Home economics", "qualType": "GCSE", "level": "Level 2" },
+        { "name": "Home economics", "qualType": "A Level", "level": "Level 3" },
+        { "name": "Home economics", "qualType": "AS Level", "level": "Level 3" },
+        { "name": "Home economics", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Horticulture and landscaping technical manager", "qualType": "End-Point Assessment", "level": "Level 5" },
+        { "name": "Horticulture Operative or Landscape", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Hospitality", "qualType": "GCSE", "level": "Level 2" },
+        { "name": "Hospitality", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Hospitality Manager", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Hospitality Supervisor", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Hospitality Team Member", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Housing and Property Management", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Housing and Property Management Assistant", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "HR consultant partner", "qualType": "End-Point Assessment", "level": "Level 5" },
+        { "name": "HR Support", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Hygiene Specialist", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "ICT", "qualType": "GCSE", "level": "Level 2" },
+        { "name": "ICT", "qualType": "A Level", "level": "Level 3" },
+        { "name": "ICT", "qualType": "AS Level", "level": "Level 3" },
+        { "name": "ICT", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Improvement leader", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Improvement practitioner", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Improvement specialist", "qualType": "End-Point Assessment", "level": "Level 5" },
+        { "name": "Improvement technician", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Industrial Coatings Applicator", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Industrial Thermal Insulation Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Information Communications Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Information Manager", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Installation Electrician and Maintenance Electrician", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Insurance practitioner", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Insurance Professional", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Intelligence Analyst", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Interior Systems Installer", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Internal Audit Practitioner", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Internal Audit Professional", "qualType": "End-Point Assessment", "level": "Level 7" },
+        { "name": "International Freight Forwarding Specialist", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Investment Operations Administrator", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Investment Operations Specialist", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Investment Operations Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Irish", "qualType": "GCSE", "level": "Level 2" },
+        { "name": "Irish", "qualType": "A Level", "level": "Level 3" },
+        { "name": "Irish", "qualType": "AS Level", "level": "Level 3" },
+        { "name": "Irish", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "IT solutions technician", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "IT Technical Salesperson", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Italian", "qualType": "GCSE", "level": "Level 2" },
+        { "name": "Italian", "qualType": "A Level", "level": "Level 3" },
+        { "name": "Italian", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Japanese", "qualType": "GCSE", "level": "Level 2" },
+        { "name": "Japanese", "qualType": "A Level", "level": "Level 3" },
+        { "name": "Japanese", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Jewellery, silversmithing, and allied trades professional", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Journalism", "qualType": "GCSE", "level": "Level 2" },
+        { "name": "Journalism", "qualType": "A Level", "level": "Level 3" },
+        { "name": "Journalism", "qualType": "AS Level", "level": "Level 3" },
+        { "name": "Journalism", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Journalist", "qualType": "End-Point Assessment", "level": "Level 5" },
+        { "name": "Junior 2D Artist  (visual effects)", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Junior advertising creative", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Junior Animator", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Junior Content Producer", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Junior Energy Manager", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Junior Estate Agent", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Junior Management Consultant", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Junior VFX Artist (Generalist)", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Keeper and aquarist", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Knitted product manufacturing technician", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Laboratory Scientist (degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Laboratory Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Land Based Service Engineer", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Land Referencer", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Land-based service engineering technician", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Landscape or Horticulture Supervisor", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Landscape Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Large Goods Vehicle( LGV) Driver C+E", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Latin", "qualType": "GCSE", "level": "Level 2" },
+        { "name": "Latin", "qualType": "A Level", "level": "Level 3" },
+        { "name": "Latin", "qualType": "AS Level", "level": "Level 3" },
+        { "name": "Latin", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Law", "qualType": "A Level", "level": "Level 3" },
+        { "name": "Law", "qualType": "AS Level", "level": "Level 3" },
+        { "name": "Law", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Lead adult care worker", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Lead Practitioner in Adult Care", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Leader in Adult Care", "qualType": "End-Point Assessment", "level": "Level 5" },
+        { "name": "Lean manufacturing operative", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Learning and development consultant business partner", "qualType": "End-Point Assessment", "level": "Level 5" },
+        { "name": "Learning and development practitioner", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Learning and Skills Teacher", "qualType": "End-Point Assessment", "level": "Level 5" },
+        { "name": "Learning Mentor", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Leather Craftsperson", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Legal Services", "qualType": "T Level", "level": "Level 3" },
+        { "name": "Leisure and tourism", "qualType": "GCSE", "level": "Level 2" },
+        { "name": "Leisure and tourism", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Leisure duty manager", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Leisure Team Member", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Level 5 Early Years Lead Practitioner", "qualType": "End-Point Assessment", "level": "Level 5" },
+        { "name": "Library, information & archive services assistant", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Licensed Conveyancer", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Life and health science", "qualType": "A Level", "level": "Level 3" },
+        { "name": "Life and health science", "qualType": "AS Level", "level": "Level 3" },
+        { "name": "Life and health science", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Lift and escalator electromechanic", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Lift Truck and Powered Access Engineering Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Lifting Equipment Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Lifting Technician", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Lightning Protection Operative", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Literature", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Live Event Rigger", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Live Event Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Livestock unit technician", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Maintenance and operations engineering technician", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Maintenance, Installation and Repair for Engineering and Manufacturing", "qualType": "T Level", "level": "Level 3" },
+        { "name": "Mammography Associate", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Management and Administration", "qualType": "T Level", "level": "Level 3" },
+        { "name": "Manufacturing engineer (degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Manufacturing Manager (integrated degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Marina and Boatyard Operative", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Marine electrician", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Marine engineer", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Marine Pilot", "qualType": "End-Point Assessment", "level": "Level 5" },
+        { "name": "Marine Surveyor (degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Marine technical superintendent (degree)", "qualType": "End-Point Assessment", "level": "Level 7" },
+        { "name": "Maritime Caterer", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Maritime mechanical and electrical mechanic", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Market research executive", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Marketing Assistant", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Marketing Executive", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Marketing Manager", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Mastic Asphalter", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Material cutter", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Materials process engineer (degree)", "qualType": "End-Point Assessment", "level": "Level 7" },
+        { "name": "Materials Science Technologist (Degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Mathematics", "qualType": "GCSE", "level": "Level 2" },
+        { "name": "Mathematics", "qualType": "A Level", "level": "Level 3" },
+        { "name": "Mathematics", "qualType": "AS Level", "level": "Level 3" },
+        { "name": "Mathematics", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Media", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Media Production Co-ordinator", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Media studies", "qualType": "GCSE", "level": "Level 2" },
+        { "name": "Media studies", "qualType": "A Level", "level": "Level 3" },
+        { "name": "Media studies", "qualType": "AS Level", "level": "Level 3" },
+        { "name": "Media studies", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Media, Broadcast and Production", "qualType": "T Level", "level": "Level 3" },
+        { "name": "Medical Statistician", "qualType": "End-Point Assessment", "level": "Level 7" },
+        { "name": "Metal casting, foundry and patternmaking technician", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Metal Fabricator", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Metal Recycling General Operative", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Metal Recycling Technical Manager (MRTM)", "qualType": "End-Point Assessment", "level": "Level 5" },
+        { "name": "Metrology Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Midwife", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Midwife (2019 NMC standards) (degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Military Engineering Construction Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Mineral and Construction Product Sampling and Testing Operations", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Mineral processing mobile and static plant operator", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Mineral Processing Weighbridge Operator", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Mineral Products Technician", "qualType": "End-Point Assessment", "level": "Level 5" },
+        { "name": "Modern Hebrew", "qualType": "GCSE", "level": "Level 2" },
+        { "name": "Modern Hebrew", "qualType": "A Level", "level": "Level 3" },
+        { "name": "Modern Hebrew", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Mortgage Adviser", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Motor Finance Specialist", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Motor Vehicle Service and Maintenance Technician (Light Vehicle)", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Motor vehicle studies", "qualType": "GCSE", "level": "Level 2" },
+        { "name": "Motor vehicle studies", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Motorcycle technician (repair and maintenance)", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Moving image arts", "qualType": "GCSE", "level": "Level 2" },
+        { "name": "Moving image arts", "qualType": "A Level", "level": "Level 3" },
+        { "name": "Moving image arts", "qualType": "AS Level", "level": "Level 3" },
+        { "name": "Moving image arts", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Museums and Galleries Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Music", "qualType": "GCSE", "level": "Level 2" },
+        { "name": "Music", "qualType": "A Level", "level": "Level 3" },
+        { "name": "Music", "qualType": "AS Level", "level": "Level 3" },
+        { "name": "Music", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Music technology", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Nail Services Technician", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Network Cable Installer", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Network Engineer", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Network Operations", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "New Furniture Product Developer", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Non-destructive testing (NDT) operator", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Non-destructive testing engineer (degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Non-destructive testing engineering technician", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Non-Home Office Police Officer", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Nuclear Health Physics Monitor", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Nuclear operative", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Nuclear reactor desk engineer", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Nuclear scientist and nuclear engineer (integrated degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Nuclear Technician", "qualType": "End-Point Assessment", "level": "Level 5" },
+        { "name": "Nuclear welding inspection technician", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "NULL", "qualType": "A Level", "level": "Level 3" },
+        { "name": "NULL", "qualType": "AS Level", "level": "Level 3" },
+        { "name": "NULL", "qualType": "AS Level", "level": "Level 3" },
+        { "name": "Nursing associate (NMC 2018)", "qualType": "End-Point Assessment", "level": "Level 5" },
+        { "name": "Occupational Therapist (Integrated Degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Officer of the watch (near coastal)", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Onsite Construction", "qualType": "T Level", "level": "Level 3" },
+        { "name": "Operating Department Practitioner (Integrated Degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Operational firefighter", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Operational Research Specialist", "qualType": "End-Point Assessment", "level": "Level 7" },
+        { "name": "Operations or departmental manager", "qualType": "End-Point Assessment", "level": "Level 5" },
+        { "name": "Optical Assistant", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Oral Health Practitioner", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Ordnance munitions and explosives (OME) professional (integrated degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Ordnance Munitions and Explosives Specialist  (integrated degree)", "qualType": "End-Point Assessment", "level": "Level 7" },
+        { "name": "Ordnance Munitions Explosives Technician", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Organ builder", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Orthodontic therapist (integrated)", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Outdoor Activity Instructor", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Outside broadcasting engineer (integrated degree)", "qualType": "End-Point Assessment", "level": "Level 7" },
+        { "name": "Packaging professional (integrated degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Packhouse Line Leader", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Painter and Decorator", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Panjabi", "qualType": "GCSE", "level": "Level 2" },
+        { "name": "Panjabi", "qualType": "A Level", "level": "Level 3" },
+        { "name": "Panjabi", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Papermaker", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Paralegal", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Paramedic (integrated degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Paraplanner", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Passenger transport driver - bus, coach and tram", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Passenger Transport Operations Manager", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Passenger transport operative", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Payroll Administrator", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Payroll Assistant Manager", "qualType": "End-Point Assessment", "level": "Level 5" },
+        { "name": "Performing arts", "qualType": "A Level", "level": "Level 3" },
+        { "name": "Performing arts", "qualType": "AS Level", "level": "Level 3" },
+        { "name": "Performing arts", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Persian", "qualType": "GCSE", "level": "Level 2" },
+        { "name": "Persian", "qualType": "A Level", "level": "Level 3" },
+        { "name": "Persian", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Personal  Trainer", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Pest Control Technician", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Pharmacy services assistant", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Pharmacy Technician (Integrated)", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Philosophy", "qualType": "A Level", "level": "Level 3" },
+        { "name": "Philosophy", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Photographic Assistant", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Photography", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Physical education", "qualType": "GCSE", "level": "Level 2" },
+        { "name": "Physical education", "qualType": "A Level", "level": "Level 3" },
+        { "name": "Physical education", "qualType": "AS Level", "level": "Level 3" },
+        { "name": "Physical education", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Physician Associate", "qualType": "End-Point Assessment", "level": "Level 7" },
+        { "name": "Physics", "qualType": "GCSE", "level": "Level 2" },
+        { "name": "Physics", "qualType": "A Level", "level": "Level 3" },
+        { "name": "Physics", "qualType": "AS Level", "level": "Level 3" },
+        { "name": "Physics", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Physiotherapist (Integrated Degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Piling Attendant", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Pipe Welder", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Plasterer", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Plate Welder", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Play therapist", "qualType": "End-Point Assessment", "level": "Level 7" },
+        { "name": "Plumbing and Domestic Heating Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Podiatrist (integrated degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Police Community Support Officer", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Police Constable (integrated degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Policy Officer", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Polish", "qualType": "GCSE", "level": "Level 2" },
+        { "name": "Polish", "qualType": "A Level", "level": "Level 3" },
+        { "name": "Polish", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Political studies", "qualType": "GCSE", "level": "Level 2" },
+        { "name": "Political studies", "qualType": "A Level", "level": "Level 3" },
+        { "name": "Political studies", "qualType": "AS Level", "level": "Level 3" },
+        { "name": "Political studies", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Port Marine Operations Officer", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Port operative", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Portuguese", "qualType": "GCSE", "level": "Level 2" },
+        { "name": "Portuguese", "qualType": "A Level", "level": "Level 3" },
+        { "name": "Portuguese", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Post graduate engineer", "qualType": "End-Point Assessment", "level": "Level 7" },
+        { "name": "Post Production Engineer", "qualType": "End-Point Assessment", "level": "Level 5" },
+        { "name": "Post- Production Technical Operator", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Poultry Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Poultry Worker", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Power and Propulsion Gas Turbine Engineer", "qualType": "End-Point Assessment", "level": "Level 7" },
+        { "name": "Power Network Craftsperson", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Powered Pedestrian Door Installer and Service Engineer", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Preparation for life and work", "qualType": "GCSE", "level": "Level 2" },
+        { "name": "Preparation for life and work", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Print operative", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Print Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Probate Technician", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Process automation engineer (degree)", "qualType": "End-Point Assessment", "level": "Level 7" },
+        { "name": "Process leader", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Procurement and supply assistant", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Product design and development engineer (degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Production arts", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Production Chef", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Professional Accounting or Taxation Technician", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Professional Arboriculturist", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Professional economist (integrated degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Professional Forester", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Project", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Project controls professional", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Project Controls Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Project Manager (integrated degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Property Maintenance Operative", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Props Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Propulsion Technician", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Prosthetic and Orthotic technician", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Prosthetist and Orthotist (Integrated Degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Psychological Wellbeing Practitioner (PWP)", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Psychology", "qualType": "GCSE", "level": "Level 2" },
+        { "name": "Psychology", "qualType": "A Level", "level": "Level 3" },
+        { "name": "Psychology", "qualType": "AS Level", "level": "Level 3" },
+        { "name": "Psychology", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Public health practitioner (integrated degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Public relations and communications assistant", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Public sector compliance Investigator and officer", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Public Service Operational Delivery Officer", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Publishing Assistant", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Quality Practitioner", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Radio Network Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Rail  engineering  advanced technician", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Rail & Rail Systems Senior Engineer (integrated degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Rail and Rail Systems Engineer", "qualType": "End-Point Assessment", "level": "Level 5" },
+        { "name": "Rail and rail systems principal engineer (integrated degree)", "qualType": "End-Point Assessment", "level": "Level 7" },
+        { "name": "Rail Engineering Operative", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Rail Engineering Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Rail Infrastructure Operator", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Railway Engineering Design Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Recruitment Consultant", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Recruitment Resourcer", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Refrigeration air conditioning and heat pump engineering technician", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Registered Nurse  - Degree (NMC 2010)", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Registered Nurse Degree (NMC 2018)", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Registrar (Creative and Cultural)", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Regulatory Affairs Specialist", "qualType": "End-Point Assessment", "level": "Level 7" },
+        { "name": "Regulatory Compliance Officer", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Rehabilitation Worker (Visual Impairment)", "qualType": "End-Point Assessment", "level": "Level 5" },
+        { "name": "Religious", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Religious studies", "qualType": "GCSE", "level": "Level 2" },
+        { "name": "Religious studies", "qualType": "A Level", "level": "Level 3" },
+        { "name": "Religious studies", "qualType": "AS Level", "level": "Level 3" },
+        { "name": "Religious studies", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Research scientist", "qualType": "End-Point Assessment", "level": "Level 7" },
+        { "name": "Retail leadership degree apprenticeship", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Retail Manager", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Retail Team Leader", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Retailer", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Revenues and Welfare Benefits Practitioner", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Risk and safety management professional (degree)", "qualType": "End-Point Assessment", "level": "Level 7" },
+        { "name": "Road surfacing operative", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Road Transport engineering manager", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Roofer", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Russian", "qualType": "GCSE", "level": "Level 2" },
+        { "name": "Russian", "qualType": "A Level", "level": "Level 3" },
+        { "name": "Russian", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Safety, health and environment technician", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Sales Executive", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Scaffolder", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "School Business Professional", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Science", "qualType": "GCSE", "level": "Level 2" },
+        { "name": "Science", "qualType": "T Level", "level": "Level 3" },
+        { "name": "Science", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Science Industry Maintenance Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Science industry process and plant engineer (degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Science manufacturing process operative", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Science Manufacturing Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Seafarer (Deck Rating)", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Security First Line Manager", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Senior and head of facilities management (integrated degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Senior compliance and risk specialist", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Senior Culinary Chef", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Senior Equine Groom", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Senior financial services customer adviser", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Senior Healthcare Support Worker", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Senior housing and property management", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Senior Insurance Professional", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Senior investment and commercial banking professional", "qualType": "End-Point Assessment", "level": "Level 7" },
+        { "name": "Senior Journalist", "qualType": "End-Point Assessment", "level": "Level 7" },
+        { "name": "Senior Leader", "qualType": "End-Point Assessment", "level": "Level 7" },
+        { "name": "Senior Metrology Technician", "qualType": "End-Point Assessment", "level": "Level 5" },
+        { "name": "Senior People Professional", "qualType": "End-Point Assessment", "level": "Level 7" },
+        { "name": "Senior Production Chef", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Senior professional economist (integrated degree)", "qualType": "End-Point Assessment", "level": "Level 7" },
+        { "name": "Serious and complex crime investigator (integrated degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Sewing machinist", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Signage technician", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Smart Home Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Social worker (integrated degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Sociology", "qualType": "GCSE", "level": "Level 2" },
+        { "name": "Sociology", "qualType": "A Level", "level": "Level 3" },
+        { "name": "Sociology", "qualType": "AS Level", "level": "Level 3" },
+        { "name": "Sociology", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Software Developer", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Software Development Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Software Tester", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Solicitor", "qualType": "End-Point Assessment", "level": "Level 7" },
+        { "name": "Sonographer (Integrated degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Space Engineering Technician", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Spanish", "qualType": "GCSE", "level": "Level 2" },
+        { "name": "Spanish", "qualType": "A Level", "level": "Level 3" },
+        { "name": "Spanish", "qualType": "AS Level", "level": "Level 3" },
+        { "name": "Spanish", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Specialist community and public health nurse", "qualType": "End-Point Assessment", "level": "Level 7" },
+        { "name": "Specialist Rescue Operative", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Specialist Tyre Operative", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Spectacle maker", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Speech and Language Therapist (Integrated Degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Sport", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Sporting Excellence Professional", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Sports coach", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Sports Turf Operative", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Stained glass craftsperson", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Stairlift, Platform Lift, Service Lift Electromechanic", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Statistics", "qualType": "GCSE", "level": "Level 2" },
+        { "name": "Statistics", "qualType": "A Level", "level": "Level 3" },
+        { "name": "Statistics", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Steel fixer", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Stonemason", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Storyboard Artist", "qualType": "End-Point Assessment", "level": "Level 7" },
+        { "name": "Structural Steelwork Erector", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Structural Steelwork Fabricator", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Supply chain leadership professional (integrated degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Supply Chain Operator", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Supply Chain Practitioner (Fast Moving Consumer Good)", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Supply Chain Warehouse Operative", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Surveying Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Survival equipment fitter", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Sustainability business specialist  (integrated degree)", "qualType": "End-Point Assessment", "level": "Level 7" },
+        { "name": "Systems Engineer", "qualType": "End-Point Assessment", "level": "Level 7" },
+        { "name": "Systems Thinking Practitioner", "qualType": "End-Point Assessment", "level": "Level 7" },
+        { "name": "Teacher", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Teaching Assistant", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Team Leader or supervisor", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Technical dyer and colourist", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Technician Scientist", "qualType": "End-Point Assessment", "level": "Level 5" },
+        { "name": "Telecoms Field Operative", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Textile care operative", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Textile Manufacturing Operative", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Textile Technical Specialist", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Theatre", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Therapeutic Radiographer (Integrated Degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Through life engineering services specialist (integrated degree)", "qualType": "End-Point Assessment", "level": "Level 7" },
+        { "name": "Tool process design engineer", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Town Planning Assistant", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Trade Supplier", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Trade Union Official", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Train Driver", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Tramway Construction Operative", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Transport Planner (Integrated Degree)", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "Transport Planning Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Travel and Tourism", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Travel Consultant", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Tunnelling Operative", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Turkish", "qualType": "GCSE", "level": "Level 2" },
+        { "name": "Turkish", "qualType": "A Level", "level": "Level 3" },
+        { "name": "Turkish", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Underkeeper", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Unified Communications Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Urban Driver", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Urdu", "qualType": "GCSE", "level": "Level 2" },
+        { "name": "Urdu", "qualType": "A Level", "level": "Level 3" },
+        { "name": "Urdu", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Utilities engineering technician", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Vehicle Damage Assessor", "qualType": "End-Point Assessment", "level": "Level 4" },
+        { "name": "Vehicle damage mechanical electrical and trim (MET) technician", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Vehicle Damage Paint Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Vehicle Damage Panel Technician", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Vet technician (livestock)", "qualType": "End-Point Assessment", "level": "Level 5" },
+        { "name": "Veterinary Nurse", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "VFX artist or technical director", "qualType": "End-Point Assessment", "level": "Level 6" },
+        { "name": "VFX Supervisor", "qualType": "End-Point Assessment", "level": "Level 7" },
+        { "name": "Wall and Floor Tiler", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Waste Resource Operative", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Watchmaker", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Water Environment Worker", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Water network operative", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Water process operative", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Water process technician", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Water treatment technician", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Wellbeing  and holistic Therapist", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Welsh second language", "qualType": "A Level", "level": "Level 3" },
+        { "name": "Welsh second language", "qualType": "AS Level", "level": "Level 3" },
+        { "name": "Welsh second language", "qualType": "Other qualification type", "level": "Other qualification level" },
+        { "name": "Wireless Communications Rigger", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Wood product manufacturing operative", "qualType": "End-Point Assessment", "level": "Level 2" },
+        { "name": "Workboat Crewmember", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Workplace Pensions (Administrator or Consultant)", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Youth justice practitioner", "qualType": "End-Point Assessment", "level": "Level 5" },
+        { "name": "Youth support worker", "qualType": "End-Point Assessment", "level": "Level 3" },
+        { "name": "Youth worker", "qualType": "End-Point Assessment", "level": "Level 6" }
+      ]
+
+      const results = rawResults.map((x, ix) => ({ id: ix, ...x }))
 
       var getSuggestions = () => {
         var suggestions = []


### PR DESCRIPTION
This fix involves 3 changes:

 - Adding IDs to the source data to uniquely identify each record
 - Changing `source` in the accessible autocomplete configuration to use a `suggest(query, populateResults)` function
   - [Documentation](https://github.com/alphagov/accessible-autocomplete#source) explaining this
 - Updating the `suggestion` template function to find by result `id` rather than by non-unique `name`

![image](https://user-images.githubusercontent.com/6364348/189308565-7e976300-86fc-4c7b-adea-31cfe22700f7.png)
