### PR TITLE
Fix a bug in the autocomplete

### DIFF
--- a/app/views/application/search/subject-search.html
+++ b/app/views/application/search/subject-search.html
@@ -23,6 +23,8 @@
       <div id="tt-default" class="autocomplete-wrapper govuk-!-margin-bottom-6"></div>
     </div>
 
+    <input type="hidden" id="selectedObject" name="selectedObject" for="selectedObject" value="{}" />
+
     <script type="text/javascript" src="/public/javascripts/accessible-autocomplete.min.js"></script>
 
     <script type="text/javascript">
@@ -1020,8 +1022,14 @@
       }
 
       function suggest(query, populateResults) {
-        const filteredResults = results.filter(x => x.name.toLowerCase().includes(query.toLowerCase()));
+        const filteredResults = results.filter(x => x.name.toLowerCase().includes(query.toLowerCase()))
         populateResults(filteredResults)
+      }
+
+      function onConfirm(confirmedValue) {
+        if (!!confirmedValue) {
+          $('#selectedObject').val(JSON.stringify(confirmedValue))
+        }
       }
 
       var element = document.querySelector('#tt-default')
@@ -1030,11 +1038,17 @@
         element: element,
         id: id,
         source: suggest,
+        onConfirm: onConfirm,
         name: "subjectSearchResult",
         templates: {
           suggestion: (value) => {
-            var result = results.find(result => result.id == value.id);
+            var result = results.find(result => result.id == value.id)
             return `<span class='job-title'>${result.name}</span><span class='govuk-hint govuk-!-margin-bottom-0'>${result.qualType}</span><span class='govuk-hint govuk-!-margin-bottom-0'> (${result.level})</span>`
+          },
+          inputValue: (selection) => {
+            if (!!selection)
+              return selection.name
+            return ""
           }
         }
       })


### PR DESCRIPTION
Bug caused '[object Object]' to appear in the input when an option was selected. The fix to this is to also provide the 'inputValue' function in the 'templates' object for the accessible autocomplete. This also required an additional 'onConfirm' function to be provided to store the full details of the selected value in a hidden input so we don't lose the detail of what qual type and level has been selected on submit

![image](https://user-images.githubusercontent.com/6364348/189356185-bf86bb0e-9246-428e-b6f2-079e6b281985.png)
