### PR TITLE
Add twitter to the options

### DIFF
--- a/app/views/register-your-interest/how-did-you-hear-about-us.html
+++ b/app/views/register-your-interest/how-did-you-hear-about-us.html
@@ -49,6 +49,9 @@
         text: "Trade journal"
       },
       {
+        text: "Twitter"
+      },
+      {
         text: "An option that isn't listed",
         conditional: {
           html: otherHtml


### PR DESCRIPTION
This PR adds Twitter as an option in the "How did you hear about us?" screen 

![Screenshot 2022-09-26 at 10 28 37](https://user-images.githubusercontent.com/1108991/192242574-73deee28-2431-4ab5-917e-d9c683f83129.png)

