### PR TITLE
Post-submit pages

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -12,6 +12,7 @@ $govuk-assets-path: '/govuk/assets/';
 @import "lib/extensions/extensions";
 
 // Overrides
+@import "overrides/moj-nav";
 // @import "overrides/blank";
 
 // Components

--- a/app/assets/sass/overrides/moj-nav.scss
+++ b/app/assets/sass/overrides/moj-nav.scss
@@ -1,0 +1,21 @@
+.app-notification-number {
+  @include govuk-font($size: 16, $line-height: 25px);
+  border-radius: 50%;
+  background-color: govuk-colour('blue');
+  color: govuk-colour('white');
+  font-weight: bold;
+  width: 25px;
+  height: 25px;
+  text-align: center;
+  display: inline-block;
+  text-decoration: none;
+  // position: absolute;
+  top: -0px;
+  right: 0;
+}
+
+.moj-primary-navigation__link:focus {
+  .app-notification-number  {
+    background-color: $govuk-focus-text-colour;
+  }
+}

--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -43,10 +43,14 @@ const trasnsportData = require('./trasnsportData.json')
 const qualificationData = require('./qualificationData.json')
 
 // Setting the default layout settings
-let settings = {
-  // Methods of searching for subjects
-  searchApproach: "Version 2"
+var settings = {
+  enableErrors: "true"  
 }
+
+var applicationData = {
+  "fullName": "Something else",
+  "opitonsChecked": ["Something", "another thing", "a third thing"]
+} 
 
 module.exports = {
 
@@ -73,16 +77,20 @@ module.exports = {
   trasnsportData,
   qualificationData,
   subjectSearch2Data,
+
+  applicationData,
+  
   settings: settings,
+  // personalDetails: personalDetails,
 
   // Setting the sections that aren't able to be started yet
-  // This will be enabled through hidden inputs in the dependant sections
-  "areaDetails": "canNotStartYet",
+  // The section is enabled with a hidden inputs in the dependant sections
+  "areaDetails": "canNotStartYet"
 
   // set a few things up to test
   // "anyAssessmentExpertise": "Yes",
   // "anyIndustryExpertise": "Yes",
   // "anyTeachingExpertise": "Yes",
-  // "teachingExpertiseCompleted": "complete"
+  // "teachingExpertiseCompleted": "complete"  
 
 }

--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -44,7 +44,7 @@ const qualificationData = require('./qualificationData.json')
 
 // Setting the default layout settings
 var settings = {
-  enableErrors: "true"  
+  enableErrors: "false"  
 }
 
 var applicationData = {

--- a/app/routes.js
+++ b/app/routes.js
@@ -419,6 +419,25 @@ router.post('/review-conflict-of-interest-answer', function (req, res) {
 
 })
 
+// Do you want to answer the equality questions?
+router.post('/equality-question-answer', function (req, res) {
+
+  let equalityQuestionAnswer = req.session.data.equalityQuestionAnswer
+
+    if (equalityQuestionAnswer === 'yes') {
+      res.redirect('/application/sorry')
+    } else {
+      res.redirect('/application/how-did-you-hear-about-this-service') 
+  }
+
+})
+
+// Sets up the dashboard with a completed application
+router.all( '/populate-dashboard', function (req, res) {
+  req.session.data = Object.assign(req.session.data.applicationData)
+  res.redirect('/application/dashboard');
+})
+
 // ------ Register your interest  ----- //
 
 // Example folder

--- a/app/views/_includes/summary-cards/application-status.html
+++ b/app/views/_includes/summary-cards/application-status.html
@@ -1,0 +1,43 @@
+  {% set applicationSubmittedTimeHtml %}
+    <time datetime="">{{ "" | today |  govukDate }}, 16:13</time>
+  {% endset %}
+
+  {% set applicationStatusHtml %}
+    {{govukTag({
+      text: "Review pending",
+      classes: "govuk-tag--yellow"
+    })}}
+  {% endset %}
+
+  {% set profileUpdatedHtml %}
+    <time datetime="">{{ "" | today |  govukDate }}, 17:55</time>
+  {% endset %}
+
+  {{ xGovukSummaryCard({
+    rows: [
+    {
+      key: {
+        text: "Application status"
+      },
+      value: {
+        html: applicationStatusHtml
+      }
+    },
+    {
+      key: {
+        text: "Application last updated"
+      },
+      value: {
+        html: profileUpdatedHtml
+      }
+    },
+    {
+      key: {
+        text: "Application submitted"
+      },
+      value: {
+        html: applicationSubmittedTimeHtml
+      }
+    }
+    ]
+  }) }}

--- a/app/views/_includes/summary-cards/personal-details.html
+++ b/app/views/_includes/summary-cards/personal-details.html
@@ -3,6 +3,8 @@
       {{ data.whereDoYouLive }}
     {% elseif data.whereDoYouLive == "Outside the UK"  %}
       {{ data.selectedCountry }}
+    {% else %}
+      Not provided
     {% endif %}
   {% endset %}
   
@@ -13,7 +15,7 @@
         text: "Full name"
       },
       value: {
-        html: data.personalDetails.fullName or "Not provided"
+        html: data.fullName or "Not provided"
       },
       actions: {
         items: [{
@@ -55,19 +57,19 @@
     }, 
     {
       key: {
-        text: "Where do you live?"
+        text: "Country"
       },
       value: {
-        html: livingLocation 
+        text: data.selectedCountry or "Not provided"
       },
       actions: {
         items: [{
           text: "Change",
-          visuallyHiddenText: "where do you live",
+          visuallyHiddenText: "Country",
           href: "/application/personal-details/where-do-you-live"
         }]
       }
-    }, 
+    } if data.whereDoYouLive == "Outside the UK", 
     {
       key: {
         text: "Address line 1"

--- a/app/views/admin.html
+++ b/app/views/admin.html
@@ -8,6 +8,22 @@
 
   <h1 class="govuk-heading-l">Admin settings<h1>
   
+  {{ govukCheckboxes({
+    fieldset: {
+      legend: {
+        text: "Enable errors on application review screen",
+        classes: "govuk-fieldset__legend--m"
+      }
+    },
+    items: [
+      {
+        value: "true",
+        text: "Enable errors"
+      }
+    ]
+  } | decorateAttributes(data, "data.settings.enableErrors")) }}
+  
+
   {# <h2 class="govuk-heading-m">Searching for subjects/qualifications<h2>
 
    {{ govukRadios({

--- a/app/views/application/dashboard.html
+++ b/app/views/application/dashboard.html
@@ -1,0 +1,46 @@
+{% extends "_templates/page-template.html" %}
+
+{% set pageHeading = "Subject matter expert dashboard" %}
+{% set backLink = "false" %}
+{% set pageType = "Dashboard" %}
+{% set primaryNavActive = "Dashboard" %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    {# <div class="govuk-grid-column-full">
+      {% set html %}
+        <h3 class="govuk-notification-banner__heading">
+          Application successfully submitted
+        </h3>
+      {% endset %}
+
+      {{ govukNotificationBanner({
+        html: html,
+        type: 'success'
+      }) }}
+    </div> #}
+    
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+
+      {# <h1 class="govuk-heading-l">{{ pageHeading }}</h1> #}
+      <h1 class="govuk-heading-l">My profile</h1>
+      <p class="govuk-body">Your applications has been submitted. You will get an email once it has been reviewed.</p>
+      <p class="govuk-body">You can still make changes to your application though any changes you make will reset and delay the review process.</p>
+    </div>
+
+   <div class="govuk-grid-column-full">   
+    <section class="govuk-!-margin-bottom-8">
+      <h2 class="govuk-heading-m govuk-!-font-size-27">Aplication status</h2>
+      {% include "_includes/summary-cards/application-status.html" %}
+    </section>
+    
+    <section class="govuk-!-margin-bottom-8">
+      <h2 class="govuk-heading-m govuk-!-font-size-27">Personal details</h2>
+      {% include "_includes/summary-cards/personal-details.html" %}
+    </section>
+
+    <p class="govuk-body">[ The full application will display here ]</p>
+  <div>
+
+{% endblock %}

--- a/app/views/application/equality-and-diversity/add-reference.html
+++ b/app/views/application/equality-and-diversity/add-reference.html
@@ -1,0 +1,57 @@
+
+{% extends "_templates/form-template.html" %}
+
+{% set pageHeading = "Add a reference" %}
+{% set formAction = "./review" %}
+
+{% block formContent %}
+
+  <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
+
+  <p class="govuk-body">You will be able to add more references after you finish telling us about the first one.</p>
+
+  {{ govukInput({
+    label: {
+      text: "Name",
+      classes: "govuk-label--m"
+    }
+  } | decorateAttributes(data, "data.reference.name")) }}
+
+  {{ govukInput({
+    label: {
+      text: "Email address",
+      classes: "govuk-label--m"
+    },
+    type: "email",
+    autocomplete: "email",
+    spellcheck: false
+  } | decorateAttributes(data, "data.reference.email")) }}
+
+  {{ govukInput({
+    label: {
+      text: "Telephone number",
+      classes: "govuk-label--m"
+    },
+    hint: {
+      text: "For international numbers include the country code" 
+    },
+    type: "tel",
+    autocomplete: "tel",
+    classes: "govuk-!-width-two-thirds"
+  } | decorateAttributes(data, "data.reference.telephone")) }}
+
+  {{ govukInput({
+    label: {
+      text: "Company or organisation name",
+      classes: "govuk-label--m"
+    }
+  } | decorateAttributes(data, "data.reference.organisation")) }}
+
+  <div class="govuk-button-group">
+    {{ govukButton({
+      text: "Save and continue"
+    }) }}
+    <a class="govuk-link govuk-body" href="/application">Cancel</a>
+  </div>
+
+{% endblock %}

--- a/app/views/application/equality-and-diversity/index.html
+++ b/app/views/application/equality-and-diversity/index.html
@@ -1,0 +1,50 @@
+
+{% extends "_templates/form-template.html" %}
+
+{% set pageHeading = "Equality and diversity" %}
+{% set formAction = "/equality-question-answer" %}
+
+{% block formContent %}
+
+  <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
+  <p class="govuk-body">Before you submit your application, we’d like to ask some equality questions.</p>
+  <p class="govuk-body">Why we ask equality questions...</p>
+
+  {% set hintHtml %}
+    These questions are optional. Your answers will not affect your application.
+  {% endset -%}
+
+  {{ govukRadios({
+    fieldset: {
+      legend: {
+        text: "Do you want to answer the equality questions?",
+        classes: "govuk-fieldset__legend--m"
+      }
+    },
+    hint: {
+      html: hintHtml
+    },
+    items: [
+      {
+        value: "yes",
+        text: "Yes, answer the equality questions (takes 2 minutes)"
+      },
+      {
+        value: "no",
+        text: "No, skip the equality questions"
+      }
+    ]
+  } | decorateAttributes(data, "data.equalityQuestionAnswer")) }}
+
+  {# {{ govukDetails({
+    summaryText: "Why we ask equality questions",
+    text: "[Consider adding an optional longer explanation of what you’re asking the questions and what you’ll do with the information]."
+  }) }} #}
+  
+  <div class="govuk-button-group">
+    {{ govukButton({
+      text: "Continue"
+    }) }}
+  </div>
+
+{% endblock %}

--- a/app/views/application/equality-and-diversity/review.html
+++ b/app/views/application/equality-and-diversity/review.html
@@ -1,0 +1,39 @@
+{% extends "_templates/form-template.html" %}
+
+{% set pageHeading = "Review your details" %}
+{% set backText = "Back to application" %}
+{% set backLink = "/application" %}
+{% set layoutWidth = "fullWidthLayout" %}
+{% set formAction = "/review-references-answer" %}
+
+{% block formContent %}
+
+  <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
+
+  {% include "_includes/summary-cards/references.html" %}
+
+  {{ govukRadios({
+  fieldset: {
+    legend: {
+      text: "Did you want to add another reference?",
+      classes: "govuk-fieldset__legend--m"
+    }
+  },
+  items: [
+    {
+      text: "Yes"
+    },
+    {
+      text: "No, I've finished adding references"
+    }
+  ]
+} | decorateAttributes(data, "data.addAnotherReference")) }}
+
+<div class="govuk-button-group">
+  {{ govukButton({
+    text: "Save and continue"
+  }) }}
+  <a class="govuk-link" href="/application">Cancel</a>
+</div>
+
+{% endblock %}

--- a/app/views/application/equality-and-diversity/section-completed.html
+++ b/app/views/application/equality-and-diversity/section-completed.html
@@ -1,0 +1,37 @@
+
+{% extends "_templates/form-template.html" %}
+
+{% set pageHeading = "Review your answers" %}
+{% set formAction = "./../../application" %}
+
+{% block formContent %}
+
+  <h1 class="govuk-heading-l">References</h1>
+  
+  {{ govukRadios({
+    fieldset: {
+      legend: {
+        text: "Have you completed this section?",
+        classes: "govuk-fieldset__legend--m"
+      }
+    },
+    items: [
+      {
+        value: "complete",
+        text: "Yes, I’ve completed this section"
+      },
+      {
+        value: "inProgress",
+        html: "No, I’ll come back to it later"
+      }
+    ]
+  } | decorateAttributes(data, "data.referencesCompleted")) }}
+
+  <div class="govuk-button-group">
+    {{ govukButton({
+      text: "Continue"
+    }) }}
+    <a class="govuk-link" href="/application">Cancel</a>
+  </div>
+
+{% endblock %}

--- a/app/views/application/how-did-you-hear-about-this-service.html
+++ b/app/views/application/how-did-you-hear-about-this-service.html
@@ -1,0 +1,70 @@
+
+{% extends "_templates/form-template.html" %}
+
+{% set serviceName = "Register your interest to be a subject expert" %}
+{% set bodyClasses = "about-you-page" %}
+{% set pageHeading = "How did you hear about this service? (optional)" %}
+{% set formAction = "./submit" %}
+
+{% block formContent %}
+
+  {% set otherHtml %}
+    {{ govukInput({
+      classes: "govuk-!-width-two-thirds",
+      label: {
+        text: "Provide details (optional)",
+        classes: "govuk-label--s"
+      }
+    } | decorateAttributes(data, "data.whereDidYouHereOther")) }}
+  {% endset -%}
+
+  {{ govukRadios({
+    fieldset: {
+      legend: {
+        text: pageHeading,
+        classes: "govuk-fieldset__legend--l",
+        isPageHeading: true
+      }
+    },
+    items: [
+      {
+        text: "Conference"
+      },
+      {
+        text: "Facebook"
+      },
+      {
+        text: "In-person meeting"
+      },
+      {
+        text: "LinkedIn"
+      },
+      {
+        text: "Online networking/webinar event"
+      },
+      {
+        text: "Personal recommendation"
+      },
+      {
+        text: "Trade journal"
+      },
+      {
+        text: "Twitter"
+      },
+      {
+        text: "An option that isn't listed",
+        conditional: {
+          html: otherHtml
+        }
+      }
+    ]
+  } | decorateAttributes(data, "data.whereDidYouHere")) }}
+
+  <div class="govuk-button-group">
+    {{ govukButton({
+      text: "Continue"
+    }) }}
+    <a class="govuk-link" href="./">Cancel</a>
+  </div>
+
+{% endblock %}

--- a/app/views/application/personal-details/index.html
+++ b/app/views/application/personal-details/index.html
@@ -20,7 +20,7 @@
         spellcheck: "false"
       },
       type: "text"
-  } | decorateAttributes(data, "data.personalDetails.fullName")) }}
+  } | decorateAttributes(data, "data.fullName")) }}
 
   {{ govukInput({
     label: {

--- a/app/views/application/review.html
+++ b/app/views/application/review.html
@@ -10,8 +10,8 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       
-      {# Only show the error summary if one or more of the sections is empty on submit  #}
-      {% if data.showErrors == "true" %}
+      {# Only show the error summary if one or more of the sections is empty on submit and errors is enabled in the admin settings #}
+      {% if data.showErrors == "true" and data.settings.enableErrors == "true" %}
         {{ govukErrorSummary({
           titleText: "Your application cannot be submitted because it’s incomplete",
           errorList: [
@@ -22,39 +22,7 @@
             {
               text: "Education and qualifications not marked as complete",
               href: "#"
-            } if data.educationDetails != "complete",
-            {
-              text: "Professional achievements is not marked as complete",
-              href: "#"
-            } if data.professionalAchievementDetails != "complete",
-            {
-              text: "Work history is not marked as complete",
-              href: "#"
-            } if data.experienceDetails != "complete",
-            {
-              text: "References is not marked as complete",
-              href: "#"
-            } if data.referenceDetails != "complete",
-            {
-              text: "Type of expertise is not marked as complete",
-              href: "#"
-            } if data.expertiseTypeDetails != "complete",
-            {
-              text: "Areas you can advise on is not marked as complete",
-              href: "#"
-            } if data.areaDetails != "complete",
-            {
-              text: "Personal statement is not marked as complete",
-              href: "#"
-            } if data.qualificationDetails != "complete",
-            {
-              text: "Conflicts of interest is not marked as complete",
-              href: "#"
-            } if data.conflictDetails != "complete",
-            {
-              text: "Verify your identity is not marked as complete",
-              href: "#"
-            } if data.qualificationDetails != "complete"
+            } if data.educationDetails != "complete"
           ]
         }) }}
 
@@ -217,19 +185,23 @@
         {% endif %} 
       </section>
       
-      <section class="govuk-!-margin-bottom-8">
-      </section>
-      
 
+      {# Only juggle this url if errors are enabled in the admin settings #}
+      {% if data.settings.enableErrors == "true" %}
       {# If there are incomplete sections we want to keep the user on this page and display an error summary  #}
       {# If all sections are complete we send them back to a completed application  #}
-      {% set reviewSubmissionHref %}
-        {% if data.personalDetails != "complete" or data.qualificationDetails != "complete" %}
-          /application/review?showErrors=true
-        {% else %}
-          /application?applicationSubmitted=true
-        {% endif %}
-      {% endset %}
+        {% set reviewSubmissionHref %}
+          {% if data.personalDetails != "complete" or data.qualificationDetails != "complete" %}
+            /application/review?showErrors=true
+          {% else %}
+            /application?applicationSubmitted=true
+          {% endif %}
+        {% endset %}
+      {% else %}
+        {% set reviewSubmissionHref %}
+          /application/equality-and-diversity 
+        {% endset %}
+      {% endif %}
 
       {{ govukButton({
         text: "Continue",

--- a/app/views/application/submit.html
+++ b/app/views/application/submit.html
@@ -1,0 +1,27 @@
+{% extends "_templates/page-template.html" %}
+
+{% set pageHeading = "Submit application" %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+
+      <h1 class="govuk-heading-xl">{{ pageHeading }}</h1>
+
+      <p class="govuk-body">
+        Is there anything we want to say here?
+      </p>
+      <p class="govuk-body">
+        By submitting this application, I confirm that the information given is true, complete and accurate.
+      </p>
+
+      {{ govukButton({
+        text: "Submit application",
+        href: "/application/dashboard?applicationStatus=submitted"
+      }) }}
+
+    </div>
+  </div>
+  
+{% endblock %}

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -23,6 +23,10 @@
         <li><a href="/application/start">Start page</a></li>
         <li><a href="/account">Create an account</a></li>
         <li><a href="/application">Your application</a></li>
+        <li><a href="/application/equality-and-diversity">Equality and diversity</a></li>
+        <li><a href="/application/how-did-you-hear-about-this-service">How did you hear about this service?</a></li>
+        <li><a href="/application/submit">Submit application</a></li>
+        <li><a href="/application/dashboard">Dashboard (application submitted - review pending)</a></li>
       </ul>
       <h2 class="govuk-heading-m">Demos</h2>
       <a href="/application/expertise/select-occupation-demo" class="govuk-body">Select an occupation (Option search/select demo)</a>

--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -54,6 +54,10 @@
   GOV.UK Prototype Kit
 {% endblock %}
 
+{% if pageType == "Dashboard"  %}
+  {% set bodyClasses = "govuk-width-container-wide app-primary-nav__on" %}
+{% endif %}
+
 {% block header %}
   {# Set serviceName in config.js. #}
   {{ govukHeader({
@@ -71,20 +75,65 @@
     } 
   ] if signedOut != "true" and serviceName != "Register your interest to be a subject expert"
   }) }}
+
+    {{ govukPhaseBanner({
+    tag: {
+      text: "prototype"
+    },
+    classes: 'govuk-!-margin-top-1 govuk-width-container',
+    html: 'This is a prototype of a new service – your <a href="#" class="govuk-link">feedback</a> will help us improve it'
+  }) }}
+
+  <div class="govuk-width-container ">
+    {% block pageNavigation %}
+    {% endblock %}  
+  </div>
+
+  {# Show primary nav if enabled #}
+  {% if pageType == "Dashboard" %}
+    <div class="moj-primary-navigation">
+      <div class="govuk-width-container">
+        <div class="moj-primary-navigation__container">
+          <div class="moj-primary-navigation__nav">
+            <nav class="moj-primary-navigation" aria-label="Primary navigation">
+              <ul class="moj-primary-navigation__list">
+                  <li class="moj-primary-navigation__item">
+                    <a class="moj-primary-navigation__link" href="/populate-dashboard" {{'aria-current="page"' if primaryNavActive == 'Dashboard'}}>My profile</a>
+                  </li>
+                  <li class="moj-primary-navigation__item">
+                    <a class="moj-primary-navigation__link" href="/application/sorry" {{'aria-current="page"' if primaryNavActive == 'manage settings'}}>Commissions</a>
+                  </li>
+                  <li class="moj-primary-navigation__item">
+                    <a class="moj-primary-navigation__link" href="/application/sorry" {{'aria-current="page"' if primaryNavActive == 'notifications'}}>Notifications
+                    <span class="app-notification-number">2</span>
+                    </a>
+                  </li>
+                </ul>
+            </nav>
+          </div>
+        </div>
+      </div>
+    </div>
+  {% endif %}
+
 {% endblock %}
 
 {% block beforeContent %}
-  {{ govukPhaseBanner({
+  {# {{ govukPhaseBanner({
     tag: {
       text: "prototype"
     },
     classes: 'govuk-!-margin-top-1',
     html: 'This is a prototype of a new service – your <a href="#" class="govuk-link">feedback</a> will help us improve it'
-  }) }}
+  }) }} #}
 
-  {% block pageNavigation %}
-  {% endblock %}  
-{% endblock %}
+  {# {% block pageNavigation %}
+  {% endblock %}   #}
+
+
+
+
+  {% endblock %}
 
 {% set mainClasses = mainClasses | default("govuk-main-wrapper--auto-spacing") %}
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test": "npm run lint && gulp generate-assets && jest"
   },
   "dependencies": {
+    "@ministryofjustice/frontend": "^1.0.1",
     "acorn": "^8.5.0",
     "ansi-colors": "^4.1.1",
     "body-parser": "^1.14.1",


### PR DESCRIPTION
This PR adds:
- a flag to enable/disable error summaries on the "review page"
- placeholders for Equality and diversity section
- a "How did you hear about this service?" screen
- a submit page
- very early "dashboard" design

![Screenshot 2022-10-11 at 09 58 19](https://user-images.githubusercontent.com/1108991/195046437-0f0f20b4-7a8f-4309-a04c-ba670bbdbcef.png)

![Screenshot 2022-10-11 at 08 58 22](https://user-images.githubusercontent.com/1108991/195045586-d4e78c30-2be0-4d6c-9786-c87b1d365c1f.png)

![Screenshot 2022-10-11 at 08 58 30](https://user-images.githubusercontent.com/1108991/195045615-9c3286c6-efbe-4ff2-b22c-df7525274878.png)

![Screenshot 2022-10-11 at 08 58 39](https://user-images.githubusercontent.com/1108991/195045645-26a2fc0f-0add-4f20-b8ef-2a4472854e05.png)

![Screenshot 2022-10-11 at 08 58 47](https://user-images.githubusercontent.com/1108991/195045669-36d84877-3f1a-423b-ac55-2acd67c8bf89.png)

![localhost_3000_application_dashboard_applicationStatus=submitted](https://user-images.githubusercontent.com/1108991/195045696-16f2536b-efde-47f2-85fc-19cba5ac6cf3.png)

