### PR TITLE
Enable "add another area" loop

### DIFF
--- a/app/data/qualificationData.json
+++ b/app/data/qualificationData.json
@@ -1,12 +1,13 @@
 [
+  "End-Point Assessment",
   "English for speakers of other languages (ESOL)",
   "Essential digital skills",
   "Functional skills",
-  "GCE AS/A Level",
+  "GCE A Level",
+  "GCE AS Level",
   "GCSE (9 to 1)",
   "GCSE (A* to G)",
-  "Occupational qualification",
-  "Other general qualification",
-  "Performing arts graded examination",
-  "Vocationally related qualification"
+  "Performing Arts Graded Examination",
+  "Technical Qualification",
+  "Vocationally-Related Qualification"
 ]

--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -85,7 +85,7 @@ module.exports = {
 
   // Setting the sections that aren't able to be started yet
   // The section is enabled with a hidden inputs in the dependant sections
-  "areaDetails": "canNotStartYet"
+  // "areaDetails": "canNotStartYet"
 
   // set a few things up to test
   // "anyAssessmentExpertise": "Yes",

--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -85,7 +85,7 @@ module.exports = {
 
   // Setting the sections that aren't able to be started yet
   // The section is enabled with a hidden inputs in the dependant sections
-  // "areaDetails": "canNotStartYet"
+  "areaDetails": "canNotStartYet"
 
   // set a few things up to test
   // "anyAssessmentExpertise": "Yes",

--- a/app/routes.js
+++ b/app/routes.js
@@ -411,7 +411,7 @@ router.post('/review-subjects-answer', function (req, res) {
   let addAnotherSubject = req.session.data.addAnotherSubject
 
     if (addAnotherSubject === 'Yes') {
-      res.redirect('/application/sorry')
+      res.redirect('/application/search/search-by-subject')
     } else {
       res.redirect('/application/search/section-completed') 
   }

--- a/app/views/_includes/summary-cards/subjects.html
+++ b/app/views/_includes/summary-cards/subjects.html
@@ -33,7 +33,7 @@
 {% endset %}
 
 {% set levelHtml %}
-  {% if data.resultQualType == "Other qualification level" %}
+  {% if data.resultQualType == "Other qualification type" %}
     <ul class="govuk-list">
       {# loops through and gets al the checked items  #}
       {% for level in data.selectedLevel %}
@@ -47,6 +47,7 @@
       {% endfor %}
     </ul>
   {% else %}
+    test
     {{ data.resultLevel }}
   {% endif %}
 {% endset %}
@@ -54,7 +55,7 @@
 {% set levelSectorHtml %}
   <ul class="govuk-list">
     {# loops through and gets al the checked items  #}
-    {% for level in data.selectedLevel %}
+    {% for level in data.selectedLevelSector %}
       <li>
         {% if level == "A qualification level that isn't listed" %}
           {{ data.selectedLevelOther }}
@@ -115,7 +116,7 @@
           items: [{
             text: "Change",
             visuallyHiddenText: "Qualification type",
-            href: "./select-qualification"
+            href: "./select-qualification?referrer=subjectSearch"
           }]
         } if data.resultQualType == "Other qualification type"
       },
@@ -130,7 +131,7 @@
           items: [{
             text: "Change",
             visuallyHiddenText: "Qualification level",
-            href: "./select-level"
+            href: "./select-level?referrer=subjectSearch"
           }]
         } if data.resultQualType == "Other qualification type"
       },

--- a/app/views/_includes/summary-cards/subjects.html
+++ b/app/views/_includes/summary-cards/subjects.html
@@ -1,5 +1,5 @@
 {% set qualTypeHtml %}
-  {% if data.resultQualType == "Other qualification type" or data.referrer == "sectorSearch" %}
+  {% if data.resultQualType == "Other qualification type" %}
     <ul class="govuk-list">
       {# loops through and gets al the checked items  #}
       {% for qualificationType in data.selectedQualification %}
@@ -17,8 +17,23 @@
   {% endif %}
 {% endset %}
 
+{% set qualTypeSectorHtml %}
+  <ul class="govuk-list">
+    {# loops through and gets al the checked items  #}
+    {% for qualificationType in data.selectedQualificationSector %}
+      <li>
+        {% if qualificationType == "A qualification type that isn't listed" %}
+          {{ data.selectedQualificationOther }}
+        {% else %} 
+          {{ qualificationType }}
+        {% endif %}
+      </li>
+    {% endfor %}
+  </ul>
+{% endset %}
+
 {% set levelHtml %}
-  {% if data.resultQualType == "Other qualification level" or data.referrer == "sectorSearch" %}
+  {% if data.resultQualType == "Other qualification level" %}
     <ul class="govuk-list">
       {# loops through and gets al the checked items  #}
       {% for level in data.selectedLevel %}
@@ -36,15 +51,30 @@
   {% endif %}
 {% endset %}
 
+{% set levelSectorHtml %}
+  <ul class="govuk-list">
+    {# loops through and gets al the checked items  #}
+    {% for level in data.selectedLevel %}
+      <li>
+        {% if level == "A qualification level that isn't listed" %}
+          {{ data.selectedLevelOther }}
+        {% else %} 
+          {{ level }}
+        {% endif %}
+      </li>
+    {% endfor %}
+  </ul>
+{% endset %}
+
 {% set expertiseTypeHtml %}
-    <ul class="govuk-list">
-      {# loops through and gets al the checked items  #}
-      {% for type in data.expertiseType %}
-        <li>
-          {{ type }}
-        </li>
-      {% endfor %}
-    </ul>
+  <ul class="govuk-list">
+    {# loops through and gets al the checked items  #}
+    {% for type in data.expertiseType %}
+      <li>
+        {{ type }}
+      </li>
+    {% endfor %}
+  </ul>
 {% endset %}
 
 {# If it is a subjects, apprenticeships or T Level  #}
@@ -121,9 +151,10 @@
       } if data.hasMultipleExpertiseTypes
     ]
   }) }}
+{% endif %}
 
-{# Must its a sector or industry  #}
-{% else %}
+{# If a sector or industry has been selected  #}
+{% if data.selectedIndustry %}
   {{ xGovukSummaryCard({
     titleText: data.selectedIndustry,
     actions: {
@@ -154,13 +185,13 @@
           text: "Qualification type"
         },
         value: { 
-          html: qualTypeHtml
+          html: qualTypeSectorHtml
         },
         actions: {
           items: [{
             text: "Change",
             visuallyHiddenText: "Qualification type",
-            href: "./select-qualification"
+            href: "./select-qualification?referrer=sectorSearch"
           }]
         }
       },
@@ -169,13 +200,13 @@
           text: "Qualification level"
         },
         value: { 
-          html: levelHtml
+          html: levelSectorHtml 
         },
         actions: {
           items: [{
             text: "Change",
             visuallyHiddenText: "Qualification level",
-            href: "./select-level"
+            href: "./select-level?referrer=sectorSearch"
           }]
         }
       },

--- a/app/views/application/expertise/select-qualification.html
+++ b/app/views/application/expertise/select-qualification.html
@@ -2,7 +2,7 @@
 {% extends "_templates/form-template.html" %}
 
 {% set formAction = "/application/expertise/select-level" %}
-{% set pageHeading = "Select the qualifications you have expertise in for this subject" %}
+{% set pageHeading = "test Select the qualifications you have expertise in for this subject" %}
 
 {% block formContent %}
 
@@ -52,6 +52,21 @@
     },
     items: qualifications
   } | decorateAttributes(data, "data.selectedQualification")) }}
+  
+  {{ govukCheckboxes({
+    fieldset: {
+      legend: {
+        text: pageHeading,
+        classes: "govuk-fieldset__legend--l",
+        isPgeHeading: true
+      }
+    },
+    hint: {
+      text: "Select all that apply"
+    },
+    items: qualifications
+  } | decorateAttributes(data, "data.selectedQualificationSector")) }}
+  
 
   <div class="govuk-button-group">
     {{ govukButton({

--- a/app/views/application/search/select-level.html
+++ b/app/views/application/search/select-level.html
@@ -38,7 +38,84 @@
     Select all that apply. Learn more about what <a href="https://www.gov.uk/what-different-qualification-levels-mean/list-of-qualification-levels" class="govuk-link" rel="noreferrer noopener" target="_blank">qualification levels mean (opens in new tab)</a>.
   {% endset %}
   
-  <section id="human-resources">
+  {# If they are coming throug the select a sector flow #}
+  {% if data.referrer == "sectorSearch" %}
+  
+    {{ govukCheckboxes({
+      fieldset: {
+        legend: {
+          text: pageHeading,
+          classes: "govuk-fieldset__legend--l",
+          isPgeHeading: false
+        }
+      },
+      hint: {
+        html: hintHtml
+      },
+      items: [
+        {
+          value: "Level 1",
+          text: "Level 1",
+          hint: {
+            text: "First certificate or or GCSE - grade 3 or D and below for example"
+          }
+        },
+        {
+          value: "Level 2",
+          text: "Level 2",
+          checked: true if "GCSE (9 to 1)" in data.selectedQualificationSector or "GCSE (A* to G)" in data.selectedQualificationSector, 
+          hint: {
+            text: "Intermediate apprenticeship or GCSE - grade 4 or C and above for example"
+          }
+        },
+        {
+          value: "Level 3",
+          text: "Level 3",
+          checked: true if "GCE A Level" in data.selectedQualificationSector or "GCE AS Level" in data.selectedQualificationSector,
+          hint: {
+            text: "A/AS level or advanced apprenticeship for example"
+          }
+        },
+        {
+          value: "Level 4",
+          text: "Level 4",
+          hint: {
+            text: "Certificate of higher education (CertHE) or higher apprenticeship for example"
+          }
+        },
+        {
+          value: "Level 5",
+          text: "Level 5",
+          hint: {
+            text: "Diploma of higher education (DipHE) or foundation degree for example"
+          }
+        },
+        {
+          value: "Level 6",
+          text: "Level 6",
+          hint: {
+            text: "Degree apprenticeship, degree with honours, graduate certificate or graduate diploma for example"
+          }
+        },
+        {
+          value: "Level 7",
+          text: "Level 7",
+          hint: {
+            text: "Master’s degree, postgraduate certificate or postgraduate diploma for example"
+          }
+        },
+        {
+          text: "A qualification level that isn't listed",
+          conditional: {
+            html: otherLevelHtml
+          }
+        }
+      ]
+    } | decorateAttributes(data, "data.selectedLevel")) }}
+
+  {# else they must be coming through subejct flow #}
+  {% else %}
+
     {{ govukCheckboxes({
       fieldset: {
         legend: {
@@ -109,8 +186,9 @@
           }
         }
       ]
-    } | decorateAttributes(data, "data.selectedLevel")) }}
-  </section>
+    } | decorateAttributes(data, "data.selectedLevelSector")) }}
+
+  {% endif %}
 
   <div class="govuk-button-group">
     {{ govukButton({

--- a/app/views/application/search/select-level.html
+++ b/app/views/application/search/select-level.html
@@ -54,6 +54,9 @@
       },
       items: [
         {
+          text: "Entry Level"
+        },
+        {
           value: "Level 1",
           text: "Sector Level 1",
           hint: {
@@ -105,9 +108,10 @@
           }
         },
         {
-          text: "A qualification level that isn't listed",
-          conditional: {
-            html: otherLevelHtml
+          value: "Level 8",
+          text: "Level 8",
+          _hint: {
+            text: "Master’s degree, postgraduate certificate or postgraduate diploma for example"
           }
         }
       ]
@@ -128,6 +132,9 @@
         html: hintHtml
       },
       items: [
+        {
+          text: "Entry Level"
+        },
         {
           value: "Level 1",
           text: "Subject Level 1",
@@ -180,9 +187,10 @@
           }
         },
         {
-          text: "A qualification level that isn't listed",
-          conditional: {
-            html: otherLevelHtml
+          value: "Level 8",
+          text: "Level 8",
+          _hint: {
+            text: "Master’s degree, postgraduate certificate or postgraduate diploma for example"
           }
         }
       ]

--- a/app/views/application/search/select-level.html
+++ b/app/views/application/search/select-level.html
@@ -55,7 +55,7 @@
       items: [
         {
           value: "Level 1",
-          text: "Level 1",
+          text: "Sector Level 1",
           hint: {
             text: "First certificate or or GCSE - grade 3 or D and below for example"
           }
@@ -111,7 +111,7 @@
           }
         }
       ]
-    } | decorateAttributes(data, "data.selectedLevel")) }}
+    } | decorateAttributes(data, "data.selectedLevelSector")) }}
 
   {# else they must be coming through subejct flow #}
   {% else %}
@@ -130,7 +130,7 @@
       items: [
         {
           value: "Level 1",
-          text: "Level 1",
+          text: "Subject Level 1",
           hint: {
             text: "First certificate or or GCSE - grade 3 or D and below for example"
           }
@@ -186,7 +186,7 @@
           }
         }
       ]
-    } | decorateAttributes(data, "data.selectedLevelSector")) }}
+    } | decorateAttributes(data, "data.selectedLevel")) }}
 
   {% endif %}
 

--- a/app/views/application/search/select-qualification.html
+++ b/app/views/application/search/select-qualification.html
@@ -65,19 +65,38 @@
     }
   }) %}
 
-  {{ govukCheckboxes({
-    fieldset: {
-      legend: {
-        text: pageHeading,
-        classes: "govuk-fieldset__legend--l",
-        isPgeHeading: true
-      }
-    },
-    hint: {
-      text: "Select all that apply"
-    },
-    items: qualifications
-  } | decorateAttributes(data, "data.selectedQualification")) }}
+  {# If they are coming through the select a sector flow #}
+  {% if data.referrer == "sectorSearch" %}
+  
+    {{ govukCheckboxes({
+      fieldset: {
+        legend: {
+          text: pageHeading,
+          classes: "govuk-fieldset__legend--l",
+          isPgeHeading: true
+        }
+      },
+      hint: {
+        text: "Select all that apply"
+      },
+      items: qualifications
+    } | decorateAttributes(data, "data.selectedQualificationSector")) }}
+  {# else they must be coming through subejct flow #}
+  {% else %}
+    {{ govukCheckboxes({
+      fieldset: {
+        legend: {
+          text: pageHeading,
+          classes: "govuk-fieldset__legend--l",
+          isPgeHeading: true
+        }
+      },
+      hint: {
+        text: "Select all that apply"
+      },
+      items: qualifications
+    } | decorateAttributes(data, "data.selectedQualification")) }}
+  {% endif %}
 
   <div class="govuk-button-group">
     {{ govukButton({


### PR DESCRIPTION
This PR:
- allows uses to select "yes" on the add another loop for "Areas that you can provide expertise on"
- users can only add one subject and one sector, not two of one kind
- this is as good as its going to get in the prototype

PS This section is held together with string and sticky tape - apologies to future designers!

![localhost_3000_application_search_review](https://user-images.githubusercontent.com/1108991/196487074-691cb809-2446-4942-b70f-ca93bbd9e825.png)


 