### PR TITLE
Personal details bug fix added

### DIFF
--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -74,7 +74,6 @@ module.exports = {
   subjectSearch2Data,
   
   settings: settings,
-  // personalDetails: personalDetails,
 
   // Setting the sections that aren't able to be started yet
   // The section is enabled with a hidden inputs in the dependant sections

--- a/app/views/_includes/summary-cards/personal-details.html
+++ b/app/views/_includes/summary-cards/personal-details.html
@@ -9,8 +9,8 @@
   {% endset %}
   
   {{ xGovukSummaryCard({
-    
-    rows: [{
+    rows: [
+    {
       key: {
         text: "Full name"
       },
@@ -30,7 +30,7 @@
         text: "Email address"
       },
       value: {
-        text: data.personalDetails.email or "Not provided"
+        text: data.email or "Not provided"
       },
       actions: {
         items: [{
@@ -45,7 +45,7 @@
         text: "Telephone number"
       },
       value: {
-        text: data.personalDetails.telephone or "Not provided"
+        text: data.telephone or "Not provided"
       },
       actions: {
         items: [{
@@ -75,7 +75,7 @@
         text: "Address line 1"
       },
       value: {
-        text: data.personalDetails.addressLine1 or "Not provided"
+        text: data.addressLine1 or "Not provided"
       },
       actions: {
         items: [{
@@ -90,7 +90,7 @@
         text: "Address line 2"
       },
       value: {
-        text: data.personalDetails.addressLine2 or "Not provided"
+        text: data.addressLine2 or "Not provided"
       },
       actions: {
         items: [{
@@ -105,7 +105,7 @@
         text: "Town or city" if data.whereDoYouLive == "In the UK" else "City, town or village"
       },
       value: {
-        text: data.personalDetails.townOrCity or "Not provided"
+        text: data.townOrCity or "Not provided"
       },
       actions: {
         items: [{
@@ -120,7 +120,7 @@
         text: "Region, state or province"
       },
       value: {
-        text: data.personalDetails.region or "Not provided"
+        text: data.region or "Not provided"
       },
       actions: {
         items: [{
@@ -135,7 +135,7 @@
         text: "Postcode" if data.whereDoYouLive == "In the UK" else "ZIP or postal code"
       },
       value: {
-        text: data.personalDetails.postCode or "Not provided"
+        text: data.postCode or "Not provided"
       },
       actions: {
         items: [{

--- a/app/views/application/index.html
+++ b/app/views/application/index.html
@@ -22,7 +22,7 @@
             name: 'Personal information and contact address',
             href: 'application/personal-details',
             _href: '#',
-            taskName: data.personalDetails
+            taskName: data.personalDetailsCompleted
           })}}
         </ul>
       </section>

--- a/app/views/application/personal-details/contact-address.html
+++ b/app/views/application/personal-details/contact-address.html
@@ -14,15 +14,15 @@
     }
   }) %}
 
+  {# If they live inside the UK  #}
   {% if data.whereDoYouLive == "In the UK" %}
-
     {{ govukInput({
       label: {
         text: 'Address line 1',
         classes: "govuk-label--s"
       },
       autocomplete: "address-line1"
-    } | decorateAttributes(data, "data.personalDetails.addressLine1")) }}
+    } | decorateAttributes(data, "data.addressLine1")) }}
 
     {{ govukInput({
       label: {
@@ -30,7 +30,7 @@
         classes: "govuk-label--s"
       },
       autocomplete: "address-line2"
-    } | decorateAttributes(data, "data.personalDetails.addressLine2")) }}
+    } | decorateAttributes(data, "data.addressLine2")) }}
 
     {{ govukInput({
       label: {
@@ -39,7 +39,7 @@
       },
       classes: "govuk-!-width-two-thirds",
       autocomplete: "address-level2"
-    } | decorateAttributes(data, "data.personalDetails.townOrCity")) }}
+    } | decorateAttributes(data, "data.townOrCity")) }}
 
     {{ govukInput({
       label: {
@@ -48,18 +48,17 @@
       },
       classes: "govuk-input--width-10",
       autocomplete: "postal-code"
-    } | decorateAttributes(data, "data.personalDetails.postCode")) }}
+    } | decorateAttributes(data, "data.postCode")) }}
 
-  {% endif %}
-
-  {% if data.whereDoYouLive == "Outside the UK" %}
+  {# Must be outside the UK #}
+  {% else %}
     {{ govukInput({
       label: {
         text: 'Address line 1',
         classes: "govuk-label--s"
       },
       autocomplete: "address-line1"
-    } | decorateAttributes(data, "data.personalDetails.addressLine1")) }}
+    } | decorateAttributes(data, "data.addressLine1")) }}
 
     {{ govukInput({
       label: {
@@ -67,7 +66,7 @@
         classes: "govuk-label--s"
       },
       autocomplete: "address-line2"
-    } | decorateAttributes(data, "data.personalDetails.addressLine2")) }}
+    } | decorateAttributes(data, "data.addressLine2")) }}
 
     {{ govukInput({
       label: {
@@ -76,7 +75,7 @@
       },
       classes: "govuk-!-width-two-thirds",
       autocomplete: "address-level2"
-    } | decorateAttributes(data, "data.personalDetails.townOrCity")) }}
+    } | decorateAttributes(data, "data.townOrCity")) }}
     
     {{ govukInput({
       label: {
@@ -85,7 +84,7 @@
       },
       classes: "govuk-!-width-two-thirds",
       autocomplete: "address-level2"
-    } | decorateAttributes(data, "data.personalDetails.region")) }}
+    } | decorateAttributes(data, "data.region")) }}
 
     {{ govukInput({
       label: {
@@ -94,7 +93,7 @@
       },
       classes: "govuk-input--width-10",
       autocomplete: "postal-code"
-    } | decorateAttributes(data, "data.personalDetails.postCode")) }}
+    } | decorateAttributes(data, "data.postCode")) }}
   {% endif %}
 
   {% endcall %}

--- a/app/views/application/personal-details/index.html
+++ b/app/views/application/personal-details/index.html
@@ -4,7 +4,7 @@
 {% set pageHeading = "Personal details" %}
 {% set formAction = "./personal-details/where-do-you-live" %}
 
-{{ data.personalDetails | log }}
+{{ data.personalDetailsCompleted | log }}
 
 {% block formContent %}
 
@@ -30,7 +30,7 @@
     type: "email",
     autocomplete: "email",
     spellcheck: false
-  } | decorateAttributes(data, "data.personalDetails.email")) }}
+  } | decorateAttributes(data, "data.email")) }}
 
   {{ govukInput({
     label: {
@@ -43,62 +43,8 @@
     type: "tel",
     autocomplete: "tel",
     classes: "govuk-!-width-two-thirds"
- } | decorateAttributes(data, "data.personalDetails.telephone")) }}
+ } | decorateAttributes(data, "data.telephone")) }}
 
-  {# {% call govukFieldset({
-    legend: {
-      text: "Your address",
-      classes: "govuk-fieldset__legend--m",
-      isPageHeading: false
-    }
-  }) %}
-
-    {{ govukInput({
-      label: {
-        text: 'Address line 1',
-        classes: "govuk-label--s"
-      },
-      autocomplete: "address-line1"
-    } | decorateAttributes(data, "data.personalDetails.addressLine1")) }}
-
-    {{ govukInput({
-      label: {
-        text: 'Address line 2 (optional)',
-        classes: "govuk-label--s"
-      },
-      autocomplete: "address-line2"
-    } | decorateAttributes(data, "data.personalDetails.addressLine2")) }}
-
-    {{ govukInput({
-      label: {
-        text: "Town or city",
-        classes: "govuk-label--s"
-      },
-      classes: "govuk-!-width-two-thirds",
-      autocomplete: "address-level2"
-    } | decorateAttributes(data, "data.personalDetails.townOrCity")) }}
-
-    {{ govukInput({
-      label: {
-        text: "County (optional)",
-        classes: "govuk-label--s"
-      },
-      classes: "govuk-!-width-two-thirds"
-    } | decorateAttributes(data, "data.personalDetails.county")) }}
-
-    {{ govukInput({
-      label: {
-        text: "Postcode",
-        classes: "govuk-label--s"
-      },
-      classes: "govuk-input--width-10",
-      autocomplete: "postal-code"
-    } | decorateAttributes(data, "data.personalDetails.postCode")) }}
-
-  {% endcall %} #}
-  
-  {# This sets a flag in the data to tell us the user has started the this section #}
-  {# <input type="hidden" id="personalDetails" name="personalDetails" value="inProgress"> #}
 
   <div class="govuk-button-group">
     {{ govukButton({

--- a/app/views/application/personal-details/section-completed.html
+++ b/app/views/application/personal-details/section-completed.html
@@ -2,7 +2,6 @@
 {% extends "_templates/form-template.html" %}
 
 {% set pageHeading = "Review your answers" %}
-{# {% set formAction = "/review-expertise-answer" %} #}
 {% set formAction = "./../../application" %}
 
 {% block formContent %}
@@ -26,7 +25,7 @@
         html: "No, I’ll come back to it later"
       }
     ]
-  } | decorateAttributes(data, "data.personalDetails")) }}
+  } | decorateAttributes(data, "data.personalDetailsCompleted")) }}
 
   <div class="govuk-button-group">
     {{ govukButton({

--- a/app/views/application/review.html
+++ b/app/views/application/review.html
@@ -18,7 +18,7 @@
             {
               text: "Personal details not marked as complete",
               href: "./personal-details"
-            } if data.personalDetails != "complete",
+            } if data.personalDetailsCompleted != "complete",
             {
               text: "Education and qualifications not marked as complete",
               href: "#"
@@ -32,7 +32,7 @@
 
       <section class="govuk-!-margin-bottom-8">
         <h2 class="govuk-heading-m govuk-!-font-size-27">Personal details</h2>
-        {% if data.personalDetails == "complete" %}
+        {% if data.personalDetailsCompleted == "complete" %}
           {% include "_includes/summary-cards/personal-details.html" %}
         {% else %}
           {{ appInsetText({
@@ -201,7 +201,7 @@
       {# If there are incomplete sections we want to keep the user on this page and display an error summary  #}
       {# If all sections are complete we send them back to a completed application  #}
         {% set reviewSubmissionHref %}
-          {% if data.personalDetails != "complete" or data.qualificationDetails != "complete" %}
+          {% if data.personalDetailsCompleted != "complete" or data.qualificationDetails != "complete" %}
             /application/review?showErrors=true
           {% else %}
             /application?applicationSubmitted=true

--- a/app/views/application/self-declaration/review.html
+++ b/app/views/application/self-declaration/review.html
@@ -7,7 +7,7 @@
 {% set referrer = "" %}
 
 {# {% set formActionHref %}
-  {%- if data.personalDetails == "complete" or data.personalDetails == "inProgress"  %}
+  {%- if data.personalDetailsCompleted == "complete" or data.personalDetailsCompleted == "inProgress"  %}
     /application
   {%- else %}
     /application/personal-details/review?showPersonalDetailsErrors=true


### PR DESCRIPTION
This PR fixes the bug were personal details data wasn't being saved on review screens. I suspect there was a conflict with the `data.personalDetails` I was using to test if the section was complete.  