### PR TITLE
Update settings page

### DIFF
--- a/app/views/admin.html
+++ b/app/views/admin.html
@@ -56,7 +56,7 @@
   {{ govukCheckboxes({
     fieldset: {
       legend: {
-        text: "Enable teaching, lecturing or training expertise expertise",
+        text: "Enable teaching, lecturing or training expertise",
         classes: "govuk-fieldset__legend--m"
       }
     },

--- a/app/views/admin.html
+++ b/app/views/admin.html
@@ -23,6 +23,67 @@
     ]
   } | decorateAttributes(data, "data.settings.enableErrors")) }}
   
+  <h2 class="govuk-heading-l">Types of expertise<h2>
+  
+  {{ govukCheckboxes({
+    fieldset: {
+      legend: {
+        text: "Enable assessment expertise",
+        classes: "govuk-fieldset__legend--m"
+      }
+    },
+    items: [
+      {
+        text: "Yes"
+      }
+    ]
+  } | decorateAttributes(data, "data.anyAssessmentExpertise")) }}  
+  
+  {{ govukCheckboxes({
+    fieldset: {
+      legend: {
+        text: "Enable industry or occupational expertise",
+        classes: "govuk-fieldset__legend--m"
+      }
+    },
+    items: [
+      {
+        text: "Yes"
+      }
+    ]
+  } | decorateAttributes(data, "data.anyIndustryExpertise")) }}  
+  
+  {{ govukCheckboxes({
+    fieldset: {
+      legend: {
+        text: "Enable teaching, lecturing or training expertise expertise",
+        classes: "govuk-fieldset__legend--m"
+      }
+    },
+    items: [
+      {
+        text: "Yes"
+      }
+    ]
+  } | decorateAttributes(data, "data.anyTeachingExpertise")) }}  
+
+  <h2 class="govuk-heading-l">Areas you can advise on<h2>
+
+  {{ govukCheckboxes({
+    fieldset: {
+      legend: {
+        text: "Enable areas you can advise on",
+        classes: "govuk-fieldset__legend--m"
+      }
+    },
+    items: [
+      {
+        text: "Yes"
+      }
+    ]
+  } | decorateAttributes(data, "data.areaDetails")) }}
+
+
 
   {# <h2 class="govuk-heading-m">Searching for subjects/qualifications<h2>
 


### PR DESCRIPTION
This PR adds settings to add:

- assessment expertise
- industry or occupational expertise
- teaching, lecturing or training expertise expertise
- provides a shortcut to enables the areas you can advise on

![Screenshot 2022-10-27 at 11 45 09](https://user-images.githubusercontent.com/1108991/198264980-be2a05cc-5195-4947-9788-06e57cf79443.png)
